### PR TITLE
refactor: wrap system operations in a `System` object

### DIFF
--- a/packages/cli/bin/codemod
+++ b/packages/cli/bin/codemod
@@ -2,7 +2,7 @@
 
 const run = require('../').default;
 
-run(process.argv, process.stdin, process.stdout, process.stderr)
+run(process.argv)
   .then(status => {
     process.exit(status);
   })

--- a/packages/cli/src/System.ts
+++ b/packages/cli/src/System.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+
+export enum EntryType {
+  Unknown,
+  File,
+  Directory
+}
+
+export interface System {
+  // fs
+  readFile(path: string): Buffer;
+  readFile(path: string, encoding: string): string;
+  writeFile(path: string, contents: Buffer): void;
+  writeFile(path: string, contents: string, encoding: string): void;
+  readdir(path: string): Array<string>;
+  isFile(path: string): boolean;
+  isDirectory(path: string): boolean;
+  getEntryType(path: string): EntryType;
+
+  // process
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+}
+
+export const RealSystem: System = {
+  readFile: fs.readFileSync,
+  writeFile: fs.writeFileSync,
+  readdir: fs.readdirSync,
+
+  getEntryType(path: string): EntryType {
+    const stat = fs.statSync(path);
+
+    if (stat.isFile()) {
+      return EntryType.File;
+    } else if (stat.isDirectory()) {
+      return EntryType.Directory;
+    } else {
+      return EntryType.Unknown;
+    }
+  },
+
+  isFile(path: string): boolean {
+    return RealSystem.getEntryType(path) === EntryType.File;
+  },
+
+  isDirectory(path: string): boolean {
+    return RealSystem.getEntryType(path) === EntryType.Directory;
+  },
+
+  stdin: process.stdin,
+  stdout: process.stdout,
+  stderr: process.stderr
+};

--- a/packages/cli/test/helpers/runCodemodCLI.ts
+++ b/packages/cli/test/helpers/runCodemodCLI.ts
@@ -1,19 +1,27 @@
 import getStream = require('get-stream');
 import { PassThrough } from 'stream';
 import run from '../../src/index';
+import { RealSystem, System } from '../../src/System';
 
 export type CLIResult = { status: number; stdout: string; stderr: string };
+
+function makeTestSystem(): System {
+  return {
+    ...RealSystem,
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough()
+  };
+}
 
 export default async function runCodemodCLI(
   args: Array<string>,
   stdin: string = '',
   cwd?: string
 ): Promise<CLIResult> {
-  let stdinStream = new PassThrough();
-  let stdoutStream = new PassThrough();
-  let stderrStream = new PassThrough();
+  let sys = makeTestSystem();
 
-  stdinStream.end(new Buffer(stdin));
+  sys.stdin.end(new Buffer(stdin));
 
   let argv = [process.argv[0], require.resolve('../../bin/codemod'), ...args];
   let status: number;
@@ -24,16 +32,16 @@ export default async function runCodemodCLI(
       process.chdir(cwd);
     }
 
-    status = await run(argv, stdinStream, stdoutStream, stderrStream);
+    status = await run(argv, sys);
   } finally {
     process.chdir(oldCwd);
   }
 
-  stdoutStream.end();
-  stderrStream.end();
+  sys.stdout.end();
+  sys.stderr.end();
 
-  let stdout = await getStream(stdoutStream);
-  let stderr = await getStream(stderrStream);
+  let stdout = await getStream(sys.stdout);
+  let stderr = await getStream(sys.stderr);
 
   return { status, stdout, stderr };
 }


### PR DESCRIPTION
This shamelessly copies the idea from the TypeScript compiler API, and will hopefully allow use with virtual file systems (like browser or nodegit).