### PR TITLE
Introduce @codemod/matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codemod
 
-Code rewriter for automated refactors.
+Code rewriting tools for automated refactors.
 
 ## Why Codemods?
 
@@ -16,6 +16,13 @@ Since codemods are typically just code themselves, you can write one to do whate
 ## Getting Started
 
 Check out the docs for [@codemod/cli](packages/cli/README.md) for instructions on installing and using the `codemod` CLI tool.
+
+## Repository Structure
+
+This repository is a monorepo, or multi-package repository. See the READMEs for the packages here:
+
+- [`@codemod/cli` README](packages/cli/README.md)
+- [`@codemod/matchers` README](packages/matchers/README.md)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "typescript": "^3.2.4",
     "typescript-eslint-parser": "^21.0.2"
   },
-  "name": "codemod"
+  "name": "codemod",
+  "resolutions": {
+    "**/ip-regex": "^2.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": {
+    "packages": ["packages/*"],
+    "nohoist": ["**/@types/**"]
+  },
   "scripts": {
     "test": "script/ci"
   },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@ codemod rewrites JavaScript and TypeScript using babel plugins.
 
 ## Install
 
-Install from npm:
+Install from [npm](https://npmjs.com/):
 
 ```sh
 $ npm install -g @codemod/cli

--- a/packages/matchers/README.md
+++ b/packages/matchers/README.md
@@ -432,7 +432,7 @@ class StringMatching extends m.Matcher<string> {
     super();
   }
 
-  match(value: unknown): value is string {
+  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is string {
     return typeof value === 'string' && this.pattern.test(value);
   }
 }

--- a/packages/matchers/README.md
+++ b/packages/matchers/README.md
@@ -1,0 +1,467 @@
+# @codemod/matchers
+
+Matchers for JavaScript & TypeScript codemods.
+
+## Install
+
+Install from [npm](https://npmjs.com/):
+
+```sh
+$ npm install @codemod/matchers
+```
+
+## Usage
+
+> This package is primarily intended to be used by codemods with `@codemod/cli`, but can be used in any Babel plugin or JavaScript/TypeScript AST processor. Note that the examples below are all written in [TypeScript](https://typescriptlang.org/), but in most cases are identical to their JavaScript counterpart.
+
+### Simple Matching
+
+Just as you can build AST nodes with `@babel/types`, you can build AST node matchers to match an exact node with `@codemod/matchers`:
+
+```ts
+import * as m from '@codemod/matchers';
+import * as t from '@babel/types';
+
+// `matcher` only matches Identifier nodes named 'test'
+const matcher = m.identifier('test');
+
+matcher.match(t.identifier('test'));  // true
+matcher.match(t.identifier('test2')); // false
+```
+
+### Fuzzy Matching
+
+Matching exact nodes is not usually what you want, however. `@codemod/matchers` can build matchers where only part of the data is specified:
+
+```ts
+import * as m from '@codemod/matchers';
+import * as t from '@babel/types';
+
+// `matcher` matches any Identifier, regardless of name
+const matcher = m.identifier();
+
+matcher.match(t.identifier('test'));  // true
+matcher.match(t.identifier('test2')); // true
+matcher.match(t.emptyStatement());    // false
+```
+
+Here's a more complex example that matches any `console.log` calls. Assume that `expr` parses the given JS as an expression:
+
+```ts
+import * as m from '@codemod/matchers';
+
+// `matcher` matches any `console.log(…)` call
+const matcher = m.callExpression(
+  m.memberExpression(
+    m.identifier('console'),
+    m.identifier('log'),
+    false
+  )
+  // `arguments` is omitted to match anything, or we could pass `m.anything()`
+);
+
+matcher.match(expr('console.log()'));     // true
+matcher.match(expr('console.log(1, 2)')); // true
+matcher.match(expr('console.log'));       // false
+```
+
+There are a variety of fuzzy matchers that come with `@codemod/matchers`:
+
+```ts
+import * as m from '@codemod/matchers';
+
+m.anyString().match('a string');  // true
+m.anyString().match(1);           // false
+
+m.anyNumber().match(1);           // true
+m.anyNumber().match('a string');  // false
+
+m.anything().match(1);            // true
+m.anything().match('a string');   // true
+m.anything().match(expr('foo'));  // true
+m.anything().match(null);         // true
+
+m.anyNode().match(expr('a + b')); // true
+m.anyNode().match(expr('!a'));    // true
+m.anyNode().match(1);             // false
+m.anyNode().match('a string');    // false
+```
+
+### Capturing Matches
+
+Often you'll want to capture part of the node that you've matched so that you can extract information from it or edit it.
+
+```ts
+import * as m from '@codemod/matchers';
+
+// matches `console.<consoleMethod>(…)` calls
+const consoleMethod = m.capture(m.identifier());
+const matcher = m.callExpression(
+  m.memberExpression(
+    m.identifier('console'),
+    consoleMethod,
+    false
+  )
+  // `arguments` is omitted to match anything, or we could pass `m.anything()`
+);
+
+if (matcher.match(expr('console.log()'))) {
+  console.log(`found console call: ${consoleMethod.current.name}`);
+}
+
+if (matcher.match(expr('console.group("hi!")'))) {
+  console.log(`found console call: ${consoleMethod.current.name}`);
+}
+
+if (matcher.match(expr('notAConsoleCall()'))) {
+  console.log(`found console call: ${consoleMethod.current.name}`);
+}
+
+// logs:
+//   found console call: log
+//   found console call: group
+```
+
+### Back-referencing Captures
+
+Sometimes you'll want to refer to an earlier captured value in a later part of the matcher. For example, let's say you want to match a function expression which returns its argument:
+
+```ts
+import * as m from '@codemod/matchers';
+
+const argumentNameMatcher = m.capture(m.anyString());
+const matcher = m.functionExpression(
+  m.anything(),
+  [m.identifier(argumentNameMatcher)],
+  m.blockStatement([
+    m.returnStatement(
+      m.fromCapture(m.identifier(argumentNameMatcher))
+    )
+  ])
+);
+
+matcher.match(expr('function(a) { return a; })'));     // true
+matcher.match(expr('function id(a) { return a; })'));  // true
+matcher.match(expr('function(a) { return b; })'));     // false
+matcher.match(expr('function(a) { return 1; })'));     // false
+matcher.match(expr('function(a) { return a + a; })')); // false
+```
+
+### Use in a Codemod
+
+All the previous examples have matchers testing a specific AST node. This is useful for illustration, but is not typically how you'd use them. Codemods written for `@codemod/cli` are [Babel plugins](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md) and therefore use the visitor pattern to process ASTs. Here's the above example that identifies functions that do nothing but return their argument again, this time as a Babel plugin that replaces such functions with a global `IDENTITY` reference:
+
+```ts
+/**
+ * Replaces identity functions with `IDENTITY`:
+ * 
+ *   list.filter(function(a) { return a; });
+ * 
+ * becomes:
+ * 
+ *   list.filter(IDENTITY);
+ */
+import * as m from '@codemod/matchers';
+import * as t from '@babel/types';
+import { NodePath } from '@babel/traverse';
+
+export default function() {
+  return {
+    visitor: {
+      FunctionExpression(path: NodePath<t.FunctionExpression>): void {
+        const argumentNameMatcher = m.capture(m.anyString());
+        const matcher = m.functionExpression(
+          m.anything(),
+          [m.identifier(argumentNameMatcher)],
+          m.blockStatement([
+            m.returnStatement(
+              m.fromCapture(m.identifier(argumentNameMatcher))
+            )
+          ])
+        );
+
+        if (matcher.match(path.node)) {
+          path.replaceWith(t.identifier('IDENTITY'));
+        }
+      }
+    }
+  };
+};
+```
+
+Here is the same plugin again without using `@codemod/matchers`:
+
+```ts
+/**
+ * Replaces identity functions with `IDENTITY`:
+ * 
+ *   list.filter(function(a) { return a; });
+ * 
+ * becomes:
+ * 
+ *   list.filter(IDENTITY);
+ */
+import * as t from '@babel/types';
+import { NodePath } from '@babel/traverse';
+
+export default function() {
+  return {
+    visitor: {
+      /**
+       * This version of the codemod, which does not use `@codemod/matchers`,
+       * is more verbose and more likely to have subtle bugs. For example,
+       * it's easy to forget to check that the `return` statement actually has a
+       * return value before checking that it is an identifier, which would
+       * result in a crash.
+       */
+      FunctionExpression(path: NodePath<t.FunctionExpression>): void {
+        // ensure function has exactly one parameter
+        if (path.node.params.length !== 1) {
+          return;
+        }
+
+        // ensure parameter is an identifier
+        const param = path.node.params[0];
+        if (!t.isIdentifier(param)) {
+          return;
+        }
+
+        // ensure function body has exactly one statement
+        if (path.node.body.body.length !== 1) {
+          return;
+        }
+
+        // ensure that statement is a return statement
+        const statement = path.node.body.body[0];
+        if (!t.isReturnStatement(statement)) {
+          return;
+        }
+
+        // ensure the return actually returns something, an identifier
+        if (!statement.argument || !t.isIdentifier(statement.argument)) {
+          return;
+        }
+
+        // ensure returned identifier has same name as the param
+        if (statement.argument.name !== param.name) {
+          return;
+        }
+
+        // replace!
+        path.replaceWith(t.identifier('IDENTITY'));
+      }
+    }
+  };
+};
+```
+
+### Deep Matches
+
+Sometimes you know you want to match a node but don't know its depth in the tree, and thus can't hardcode a whole matching tree. To deal with this situation you can use the `containerOf` matcher. For example, this matcher will find the first `done` call inside a mocha test, accounting for whatever name might have been used for the parameter:
+
+```ts
+import * as m from '@codemod/matchers';
+
+const doneParamName = m.capture(m.anyString());
+const matcher = m.callExpression(
+  m.identifier('test'),
+  [
+    m.anyString(),
+    m.function(
+      [m.identifier(doneParam)],
+      m.containerOf(
+        m.callExpression(
+          m.identifier(m.fromCapture(doneParamName))
+        )
+      )
+    )
+  ]
+);
+
+// matches because there's a `done()` call
+matcher.match(expr(`
+  test('setTimeout calls back around N ms later', function(done) {
+    const now = Date.now();
+    const duration = 5;
+
+    setTimeout(function() {
+      assert.ok(Date.now() - now < 10);
+      done();
+    }, duration);
+  });
+`));
+
+// does not match because there's no `done()` call
+matcher.match(expr(`
+  test('adds things', function() {
+    assert.strictEqual(3 + 4, 7);
+  });
+`));
+```
+
+### Custom Matchers
+
+The easiest way to build custom matchers is simply by composing existing ones:
+
+```ts
+import * as m from '@codemod/matchers';
+import * as t from '@babel/types';
+
+function plusEqualOne() {
+  return m.assignmentExpression(
+    '+=',
+    m.anything(), // or just `undefined` for the same effect
+    m.numericLiteral(1)
+  );
+}
+
+const matcher = plusEqualOne();
+
+matcher.match(expr('a += 1'));   // true
+matcher.match(expr('a.b += 1')); // true
+matcher.match(expr('a -= 1'));   // false
+matcher.match(expr('a += 2'));   // false
+```
+
+You can build simple custom matchers easily using a predicate:
+
+```ts
+import * as m from '@codemod/matchers';
+
+const oddNumberMatcher = m.matcher(
+  value => typeof value === 'number' && Math.abs(number % 2) === 1
+);
+
+oddNumberMatcher.match(expr('-1'));       // true
+oddNumberMatcher.match(expr('0'));        // false
+oddNumberMatcher.match(expr('1'));        // true
+oddNumberMatcher.match(expr('2'));        // true
+oddNumberMatcher.match(expr('3'));        // true
+oddNumberMatcher.match(expr('Infinity')); // false
+oddNumberMatcher.match(expr('NaN'));      // false
+```
+
+Such matchers are easily parameterized by wrapping it in a function:
+
+```ts
+import * as m from '@codemod/matchers';
+
+function stringMatching(pattern: RegExp) {
+  return m.matcher(
+    value => typeof value === 'string' && pattern.test(value)
+  );
+)
+
+const startsWithRun = stringMatching(/^run/);
+
+startsWithRun.match('run');     // true
+startsWithRun.match('runner');  // true
+startsWithRun.match('running'); // true
+startsWithRun.match('ruining'); // false
+startsWithRun.match(' run');    // false
+startsWithRun.match('');        // false
+startsWithRun.match(1);         // false
+```
+
+A common case where you think you'd need a custom matcher is when you want one of a few possible values. In such cases you can use the `or` matcher:
+
+```ts
+import * as m from '@codemod/matchers';
+
+const matcher = m.or(m.anyString(), m.anyNumber());
+
+matcher.match(1);         // true
+matcher.match('string');  // true
+matcher.match({});        // false
+matcher.match(expr('1')); // false
+```
+
+Matching one of a few values is common when dealing with things such as functions, which could be arrow functions, function expressions, or function declarations. Here's a more general version of the `IDENTITY` codemod which uses the `or` matcher to also replace arrow functions:
+
+```ts
+/**
+ * Replaces identity functions with `IDENTITY`:
+ * 
+ *   list.filter(function(a) { return a; });
+ *   list2.filter(a => a);
+ * 
+ * becomes:
+ * 
+ *   list.filter(IDENTITY);
+ *   list2.filter(IDENTITY);
+ */
+import * as m from '@codemod/matchers';
+import * as t from '@babel/types';
+import { NodePath } from '@babel/traverse';
+
+export default function() {
+  return {
+    visitor: {
+      FunctionExpression(path: NodePath<t.FunctionExpression>): void {
+        const argumentNameMatcher = m.capture(m.anyString());
+        const matcher = m.function(
+          [m.identifier(argumentNameMatcher)],
+          m.or(
+            m.blockStatement([
+              m.returnStatement(
+                m.identifier(m.fromCapture(argumentNameMatcher))
+              )
+            ]),
+            m.identifier(m.fromCapture(argumentNameMatcher))
+          )
+        );
+
+        if (matcher.match(path.node)) {
+          path.replaceWith(t.identifier('IDENTITY'));
+        }
+      }
+    }
+  };
+};
+```
+
+You probably won't need it, but you can build your own by subclassing `Matcher`. Here's the same `stringMatching` but as a subclass of `Matcher`:
+
+```ts
+import * as m from '@codemod/matchers';
+import * as t from '@babel/types';
+
+// This is more ceremony than the simple predicate-based one above.
+class StringMatching extends m.Matcher<string> {
+  constructor(private readonly pattern: RegExp) {
+    super();
+  }
+
+  match(value: unknown): value is string {
+    return typeof value === 'string' && this.pattern.test(value);
+  }
+}
+
+const startsWithRun = new StringMatching(/^run/);
+
+startsWithRun.match('run');     // true
+startsWithRun.match('runner');  // true
+startsWithRun.match('running'); // true
+startsWithRun.match('ruining'); // false
+startsWithRun.match(' run');    // false
+startsWithRun.match('');        // false
+startsWithRun.match(1);         // false
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for information on setting up the project for development and on contributing to the project.
+
+## Status
+
+[![Build Status](https://travis-ci.com/codemod-js/codemod.svg?branch=master)](https://travis-ci.com/codemod-js/codemod)
+
+## License
+
+Copyright 2019 Brian Donovan
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/matchers/examples/convert-qunit-assert-expect-to-assert-async.ts
+++ b/packages/matchers/examples/convert-qunit-assert-expect-to-assert-async.ts
@@ -1,0 +1,124 @@
+/**
+ * Converts deprecated `assert.expect(N)`-style tests to use `assert.async()`.
+ *
+ * @example
+ *
+ * test('my test', function (assert) {
+ *   assert.expect(1);
+ *   window.server.get('/some/api', () => {
+ *     asyncThing().then(() => {
+ *       assert.ok(true, 'API called!');
+ *     });
+ *   });
+ *   doStuff();
+ * });
+ *
+ * // becomes
+ *
+ * test('my test', function (assert) {
+ *   const done = assert.async();
+ *   window.server.get('/some/api', () => {
+ *     asyncThing().then(() => {
+ *       assert.ok(true, 'API called!');
+ *       done();
+ *     });
+ *   });
+ *   doStuff();
+ * });
+ */
+
+import * as t from '@babel/types';
+import * as m from '../src';
+import { PluginObj } from '@babel/core';
+import { NodePath } from '@babel/traverse';
+import { BuildStatement as S } from '../src/__tests__/utils/builders';
+
+// capture name of `assert` parameter
+const assertBinding = m.capture(m.anyString());
+
+// capture `assert.expect(<number>);` inside the async test
+const assertExpect = m.capture(
+  m.expressionStatement(
+    m.callExpression(
+      m.memberExpression(
+        m.identifier(m.fromCapture(assertBinding)),
+        m.identifier('expect')
+      ),
+      [m.numericLiteral()]
+    )
+  )
+);
+
+// capture `assert.<method>(…);` inside the callback
+const callbackAssertion = m.capture(
+  m.expressionStatement(
+    m.callExpression(
+      m.memberExpression(
+        m.identifier(m.fromCapture(assertBinding)),
+        m.identifier()
+      )
+    )
+  )
+);
+
+// callback function body
+const callbackFunctionBody = m.containerOf(
+  m.blockStatement(m.anyList(m.zeroOrMore(), callbackAssertion, m.zeroOrMore()))
+);
+
+// async test function body
+const asyncTestFunctionBody = m.blockStatement(
+  m.anyList(
+    m.zeroOrMore(),
+    assertExpect,
+    m.zeroOrMore(),
+    m.expressionStatement(
+      m.callExpression(
+        undefined,
+        m.anyList(
+          m.zeroOrMore(),
+          m.or(
+            m.functionExpression(undefined, undefined, callbackFunctionBody),
+            m.arrowFunctionExpression(undefined, callbackFunctionBody)
+          )
+        )
+      )
+    ),
+    m.zeroOrMore()
+  )
+);
+
+// match the whole `test('description', function(assert) { … })`
+const asyncTestMatcher = m.callExpression(m.identifier('test'), [
+  m.stringLiteral(),
+  m.functionExpression(
+    undefined,
+    [m.identifier(assertBinding)],
+    asyncTestFunctionBody
+  )
+]);
+
+export default function(): PluginObj {
+  return {
+    visitor: {
+      CallExpression(path: NodePath<t.CallExpression>): void {
+        m.matchPath(
+          asyncTestMatcher,
+          {
+            assertExpect,
+            callbackAssertion,
+            assertBinding
+          },
+          path,
+          ({ assertExpect, callbackAssertion, assertBinding }) => {
+            assertExpect.replaceWith(
+              S`const done = ${t.identifier(assertBinding)}.async();`
+            );
+
+            callbackAssertion.insertAfter(S`done();`);
+          }
+        );
+      }
+    }
+  };
+}

--- a/packages/matchers/examples/convert-static-class-to-named-exports.ts
+++ b/packages/matchers/examples/convert-static-class-to-named-exports.ts
@@ -1,0 +1,113 @@
+import { PluginObj } from '@babel/core';
+import { NodePath } from '@babel/traverse';
+import * as t from '@babel/types';
+import * as m from '../src';
+
+const className = m.capture(m.anyString());
+const classDeclaration = m.capture(
+  m.classDeclaration(
+    m.identifier(className),
+    null,
+    m.classBody(
+      m.arrayOf(
+        m.classMethod(
+          'method',
+          m.identifier(),
+          m.anything(),
+          m.anything(),
+          false,
+          true
+        )
+      )
+    )
+  )
+);
+const exportDeclaration = m.capture(
+  m.exportDefaultDeclaration(m.identifier(m.fromCapture(className)))
+);
+const matcher = m.anyList<t.Statement>(
+  m.zeroOrMore(),
+  classDeclaration,
+  m.zeroOrMore(),
+  exportDeclaration,
+  m.zeroOrMore()
+);
+
+const thisPropertyAccessMatcher = m.memberExpression(
+  m.thisExpression(),
+  m.identifier(),
+  false
+);
+
+export default function(): PluginObj {
+  return {
+    visitor: {
+      Program(path: NodePath<t.Program>): void {
+        m.match(
+          matcher,
+          { exportDeclaration, classDeclaration },
+          path.node.body,
+          ({ exportDeclaration, classDeclaration }) => {
+            const statements = path.node.body;
+            const replacements: Array<t.Statement> = [];
+            const exportDeclarationPath = path.get('body')[
+              statements.indexOf(exportDeclaration)
+            ] as NodePath<t.ExportDefaultDeclaration>;
+            const classDeclarationPath = path.get('body')[
+              statements.indexOf(classDeclaration)
+            ] as NodePath<t.ClassDeclaration>;
+
+            for (const property of classDeclarationPath
+              .get('body')
+              .get('body')) {
+              if (!property.isClassMethod()) {
+                throw new Error(
+                  `unexpected ${property.type} while looking for ClassMethod`
+                );
+              }
+
+              if (!t.isIdentifier(property.node.key)) {
+                throw new Error(
+                  `unexpected ${
+                    property.get('key').type
+                  } while looking for Identifier`
+                );
+              }
+
+              replacements.push(
+                t.exportNamedDeclaration(
+                  t.functionDeclaration(
+                    property.node.key,
+                    property.node.params,
+                    property.node.body,
+                    property.node.generator,
+                    property.node.async
+                  ),
+                  []
+                )
+              );
+
+              property.get('body').traverse({
+                enter(path: NodePath<t.Node>): void {
+                  if (path.isFunction()) {
+                    if (!path.isArrowFunctionExpression()) {
+                      path.skip();
+                    }
+                  } else if (
+                    path.isMemberExpression() &&
+                    thisPropertyAccessMatcher.match(path.node)
+                  ) {
+                    path.replaceWith(path.node.property);
+                  }
+                }
+              });
+            }
+
+            exportDeclarationPath.remove();
+            classDeclarationPath.replaceWithMultiple(replacements);
+          }
+        );
+      }
+    }
+  };
+}

--- a/packages/matchers/jest.config.js
+++ b/packages/matchers/jest.config.js
@@ -1,0 +1,178 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after the first failure
+  // bail: false,
+
+  // Respect "browser" field in package.json when resolving modules
+  // browser: false,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/var/folders/1n/hxkwxdt95zzgp53y_5ng4gy40000gn/T/jest_dx",
+
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: false,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: null,
+
+  // The directory where Jest should output its coverage files
+  // coverageDirectory: null,
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: null,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files usin a array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: null,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: null,
+
+  // A set of global variables that need to be available in all test environments
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.json'
+    }
+  },
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+
+  // A map from regular expressions to module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "always",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: null,
+
+  // Run tests from one or more projects
+  // projects: null,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: null,
+
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: null,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // The path to a module that runs some code to configure or set up the testing framework before each test
+  // setupTestFrameworkScriptFile: null,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: 'node',
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: ['**/__tests__/*.+(ts|tsx|js)'],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern Jest uses to detect test files
+  // testRegex: "",
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: null,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  }
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: null,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -7,10 +7,13 @@
     "@babel/types": "^7.2.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.2.2",
     "@babel/generator": "^7.2.2",
     "@babel/parser": "^7.2.3",
     "@babel/traverse": "^7.2.3",
+    "@types/babel__core": "^7.0.4",
     "@types/babel__generator": "^7.0.1",
+    "@types/babel__template": "^7.0.1",
     "@types/babel__traverse": "^7.0.4",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^23.3.10",

--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@codemod/matchers",
+  "version": "0.0.0-development",
+  "description": "",
+  "main": "src/index.js",
+  "dependencies": {
+    "@babel/types": "^7.2.2"
+  },
+  "devDependencies": {
+    "@babel/generator": "^7.2.2",
+    "@babel/parser": "^7.2.3",
+    "@babel/traverse": "^7.2.3",
+    "@types/babel__generator": "^7.0.1",
+    "@types/babel__traverse": "^7.0.4",
+    "@types/dedent": "^0.7.0",
+    "@types/jest": "^23.3.10",
+    "@types/node": "^10.12.18",
+    "dedent": "^0.7.0",
+    "jest": "^23.6.0",
+    "ts-jest": "^23.10.5",
+    "typescript": "^3.2.4"
+  },
+  "scripts": {
+    "prepare": "tsc",
+    "test": "script/ci"
+  },
+  "keywords": [],
+  "author": "Brian Donovan",
+  "license": "Apache-2.0",
+  "files": [
+    "src/**/*.js",
+    "src/**/*.d.ts",
+    "src/**/*.js.map",
+    "!src/__tests__/**/*"
+  ]
+}

--- a/packages/matchers/script/_commands/ci.ts
+++ b/packages/matchers/script/_commands/ci.ts
@@ -1,0 +1,119 @@
+import rebuild, { MATCHERS_FILE_PATH } from '../_utils/rebuild';
+import { readFile } from 'mz/fs';
+import { join, relative } from 'path';
+import runNodePackageBinary from '../../../../script/_utils/runNodePackageBinary';
+
+export default async function main(
+  args: Array<string>,
+  stdin: NodeJS.ReadStream,
+  stdout: NodeJS.WriteStream,
+  stderr: NodeJS.WriteStream
+): Promise<number> {
+  const rest = args.slice(1);
+
+  switch (args[0]) {
+    case undefined:
+      return (
+        (await verifyGeneratedMatchersUpToDate(args, stdin, stdout, stderr)) ||
+        (await lint(rest, stdin, stdout, stderr)) ||
+        (await runTests(args, stdin, stdout, stderr))
+      );
+
+    case 'test':
+      return await runTests(args, stdin, stdout, stderr);
+
+    case 'lint':
+      return await lint(rest, stdin, stdout, stderr);
+
+    default:
+      throw new Error(`unexpected command: ${args[0]}`);
+  }
+}
+
+async function verifyGeneratedMatchersUpToDate(
+  args: Array<string>,
+  stdin: NodeJS.ReadStream,
+  stdout: NodeJS.WriteStream,
+  stderr: NodeJS.WriteStream
+): Promise<number> {
+  const expected = regenerateMatchersFileAsString();
+  const actual = await readFile(MATCHERS_FILE_PATH, 'utf8');
+
+  if (actual !== expected) {
+    stderr.write(
+      `\x1b[41;1;38;5;232m INVALID \x1b[0m ${relativeToCwd(
+        MATCHERS_FILE_PATH
+      )} is out of date. Please rebuild it by running ${relativeToCwd(
+        require.resolve('../rebuild')
+      )}.\n`
+    );
+    return 1;
+  } else {
+    stdout.write(
+      `\x1b[42;1;38;5;232m VALID \x1b[0m ${relativeToCwd(
+        MATCHERS_FILE_PATH
+      )} is up to date!\n`
+    );
+    return 0;
+  }
+}
+
+function relativeToCwd(path: string, cwd: string = process.cwd()): string {
+  return relative(cwd, path);
+}
+
+function regenerateMatchersFileAsString(): string {
+  let data = '';
+
+  rebuild({
+    write(chunk: string) {
+      data += chunk;
+    }
+  });
+
+  return data;
+}
+
+async function runTests(
+  args: Array<string>,
+  stdin: NodeJS.ReadStream,
+  stdout: NodeJS.WriteStream,
+  stderr: NodeJS.WriteStream
+): Promise<number> {
+  return await runNodePackageBinary(
+    'jest',
+    [],
+    join(__dirname, '../..'),
+    stdin,
+    stdout,
+    stderr
+  );
+}
+
+async function lint(
+  args: Array<string>,
+  stdin: NodeJS.ReadStream,
+  stdout: NodeJS.WriteStream,
+  stderr: NodeJS.WriteStream
+): Promise<number> {
+  return await runNodePackageBinary(
+    'eslint',
+    [
+      'packages/matchers',
+      '--ext',
+      '.ts',
+      ...(isCI()
+        ? ['--format', 'junit', '-o', 'reports/junit/eslint-results.xml']
+        : []),
+      ...args
+    ],
+    join(__dirname, '../../../..'),
+    stdin,
+    stdout,
+    stderr
+  );
+}
+
+function isCI(): boolean {
+  return process.env.CI === 'true';
+}

--- a/packages/matchers/script/_commands/rebuild.ts
+++ b/packages/matchers/script/_commands/rebuild.ts
@@ -1,0 +1,10 @@
+import rebuild, { MATCHERS_FILE_PATH } from '../_utils/rebuild';
+import { createWriteStream } from 'fs';
+
+export default function main(): Promise<number> {
+  return new Promise(resolve => {
+    const out = createWriteStream(MATCHERS_FILE_PATH, 'utf8');
+    out.once('close', () => resolve(0));
+    rebuild(out);
+  });
+}

--- a/packages/matchers/script/_utils/rebuild.ts
+++ b/packages/matchers/script/_utils/rebuild.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env ts-node
+
+import * as t from '@babel/types';
+import { join } from 'path';
+import {
+  stringifyValidator,
+  isValidatorOfType,
+  toFunctionName,
+  typeForValidator,
+  stringifyType
+} from './utils';
+import dedent = require('dedent');
+import { NodeField, BUILDER_KEYS, NODE_FIELDS } from '../../src/NodeTypes';
+
+export const MATCHERS_FILE_PATH = join(__dirname, '../../src/matchers.ts');
+
+// eslint-disable-next-line typescript/no-explicit-any
+const toBindingIdentifierName: (name: string) => string = (t as any)
+  .toBindingIdentifierName;
+
+function stringifyMatcherForField(field: NodeField): string {
+  const types = [
+    `Matcher<${stringifyValidator(field.validate, 't.', '')}>`,
+    ...possiblePrimitiveTypesForField(field)
+  ];
+
+  if (
+    isValidatorOfType('array', field.validate) &&
+    'chainOf' in field.validate
+  ) {
+    const elementType = typeForValidator(field.validate.chainOf[1]);
+
+    types.push(
+      stringifyType(elementType, (type, value) => {
+        if (t.isTSTypeReference(type)) {
+          return `Matcher<t.${value}>`;
+        } else if (
+          t.isTSLiteralType(type) ||
+          t.isTSBooleanKeyword(type) ||
+          t.isTSNumberKeyword(type) ||
+          t.isTSStringKeyword(type) ||
+          t.isTSUndefinedKeyword(type) ||
+          t.isTSNullKeyword(type)
+        ) {
+          return `Matcher<${value}>`;
+        }
+      })
+    );
+  }
+
+  if (field.optional) {
+    types.push('null');
+  }
+
+  return types.join(' | ');
+}
+
+function possiblePrimitiveTypesForField(field: NodeField): Array<string> {
+  return ['string', 'number', 'boolean'].filter(type =>
+    isValidatorOfType(type, field.validate)
+  );
+}
+
+export interface SimpleWriter {
+  write(data: string): void;
+}
+
+export default function rebuild(out: SimpleWriter): void {
+  out.write(`/* eslint-disable */\n`);
+  out.write(`import * as t from '@babel/types';\n\n`);
+
+  out.write(dedent`
+    export * from './matchers/spacers';
+    export { default as Function } from './matchers/Function';
+    export { default as Matcher } from './matchers/Matcher';
+    export { default as anyExpression } from './matchers/anyExpression';
+    export { default as anyList } from './matchers/anyList';
+    export { default as anyNode } from './matchers/anyNode';
+    export { default as anyNumber } from './matchers/anyNumber';
+    export { default as anyStatement } from './matchers/anyStatement';
+    export { default as anyString } from './matchers/anyString';
+    export { default as anything } from './matchers/anything';
+    export { default as arrayOf } from './matchers/arrayOf';
+    export { default as capture, CapturedMatcher } from './matchers/capture';
+    export { default as containerOf } from './matchers/containerOf';
+    export { default as fromCapture } from './matchers/fromCapture';
+    export { default as function } from './matchers/Function';
+    export { default as oneOf } from './matchers/oneOf';
+    export { default as or } from './matchers/or';
+    export { default as matcher } from './matchers/predicate';
+    export { default as tupleOf } from './matchers/tupleOf';
+
+    import tupleOf from './matchers/tupleOf';
+    import { isNode } from './NodeTypes';
+    import Matcher from './matchers/Matcher';
+  `);
+
+  out.write('\n\n');
+
+  out.write('// aliases for keyword-named functions\n');
+
+  const ALIASES = new Map([['Import', 'import'], ['Super', 'super']]);
+
+  for (const [original, alias] of ALIASES.entries()) {
+    out.write(`export { ${original} as ${alias} }\n`);
+  }
+
+  out.write('\n');
+
+  for (const type of Object.keys(BUILDER_KEYS)) {
+    const keys = BUILDER_KEYS[type];
+    const fields = NODE_FIELDS[type];
+    const name = ALIASES.has(type) ? type : toFunctionName(type);
+
+    out.write(`export class ${type}Matcher extends Matcher<t.${type}> {\n`);
+    out.write(`  constructor(\n`);
+    for (const key of keys) {
+      const field = fields[key];
+      const binding = toBindingIdentifierName(key);
+      out.write(
+        `    private readonly ${binding}?: ${stringifyMatcherForField(
+          field
+        )},\n`
+      );
+    }
+    out.write(`  ) {\n`);
+    out.write(`    super();\n`);
+    out.write(`  }\n`);
+    out.write(`\n`);
+    out.write(`  match(node: unknown): node is t.${type} {\n`);
+    out.write(`    if (\n`);
+    out.write(`      !isNode(node) ||\n`);
+    out.write(`      !t.is${type}(node)\n`);
+    out.write(`    ) {\n`);
+    out.write(`      return false;\n`);
+    out.write(`    }\n`);
+    out.write(`\n`);
+    for (const key of keys) {
+      const field = fields[key];
+      const binding = `this.${toBindingIdentifierName(key)}`;
+      out.write(`    if (typeof ${binding} === 'undefined') {\n`);
+      out.write(`      // undefined matcher means anything matches\n`);
+      for (const type of possiblePrimitiveTypesForField(field)) {
+        out.write(`    } else if (typeof ${binding} === '${type}') {\n`);
+        out.write(`      if (${binding} !== node.${key}) {\n`);
+        out.write(`        return false;\n`);
+        out.write(`      }\n`);
+      }
+      if (field.optional) {
+        out.write(`    } else if (${binding} === null) {\n`);
+        out.write(`      // null matcher means we expect null value\n`);
+        out.write(`      if (node.${key} !== null) {\n`);
+        out.write(`        return false;\n`);
+        out.write(`      }\n`);
+        out.write(`    } else if (node.${key} === null) {\n`);
+        out.write(`      return false;\n`);
+      }
+      if (isValidatorOfType('array', field.validate)) {
+        out.write(`    } else if (Array.isArray(${binding})) {\n`);
+        out.write(
+          `      if (!tupleOf<unknown>(...${binding}).match(node.${key})) {\n`
+        );
+        out.write(`        return false;\n`);
+        out.write(`      }\n`);
+      }
+      out.write(`    } else if (!${binding}.match(node.${key})) {\n`);
+      out.write(`      return false;\n`);
+      out.write(`    }\n`);
+      out.write(`\n`);
+    }
+    out.write(`    return true;\n`);
+    out.write(`  }\n`);
+    out.write(`}\n\n`);
+
+    out.write(`export function ${name}(\n`);
+    for (const key of keys) {
+      const field = fields[key];
+      const binding = toBindingIdentifierName(key);
+      out.write(`  ${binding}?: ${stringifyMatcherForField(field)},\n`);
+    }
+    out.write(`): Matcher<t.${type}> {\n`);
+    out.write(`  return new ${type}Matcher(\n`);
+    for (const key of keys) {
+      const binding = toBindingIdentifierName(key);
+      out.write(`    ${binding},\n`);
+    }
+    out.write(`  );\n`);
+    out.write(`}\n\n`);
+  }
+}

--- a/packages/matchers/script/_utils/rebuild.ts
+++ b/packages/matchers/script/_utils/rebuild.ts
@@ -127,7 +127,9 @@ export default function rebuild(out: SimpleWriter): void {
     out.write(`    super();\n`);
     out.write(`  }\n`);
     out.write(`\n`);
-    out.write(`  match(node: unknown): node is t.${type} {\n`);
+    out.write(
+      `  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.${type} {\n`
+    );
     out.write(`    if (\n`);
     out.write(`      !isNode(node) ||\n`);
     out.write(`      !t.is${type}(node)\n`);
@@ -137,6 +139,7 @@ export default function rebuild(out: SimpleWriter): void {
     out.write(`\n`);
     for (const key of keys) {
       const field = fields[key];
+      const keyString = `'${key}'`;
       const binding = `this.${toBindingIdentifierName(key)}`;
       out.write(`    if (typeof ${binding} === 'undefined') {\n`);
       out.write(`      // undefined matcher means anything matches\n`);
@@ -158,12 +161,14 @@ export default function rebuild(out: SimpleWriter): void {
       if (isValidatorOfType('array', field.validate)) {
         out.write(`    } else if (Array.isArray(${binding})) {\n`);
         out.write(
-          `      if (!tupleOf<unknown>(...${binding}).match(node.${key})) {\n`
+          `      if (!tupleOf<unknown>(...${binding}).matchValue(node.${key}, [...keys, ${keyString}])) {\n`
         );
         out.write(`        return false;\n`);
         out.write(`      }\n`);
       }
-      out.write(`    } else if (!${binding}.match(node.${key})) {\n`);
+      out.write(
+        `    } else if (!${binding}.matchValue(node.${key}, [...keys, ${keyString}])) {\n`
+      );
       out.write(`      return false;\n`);
       out.write(`    }\n`);
       out.write(`\n`);

--- a/packages/matchers/script/_utils/utils.ts
+++ b/packages/matchers/script/_utils/utils.ts
@@ -1,0 +1,178 @@
+import * as t from '@babel/types';
+import generate from '@babel/generator';
+
+export interface ArrayValidator {
+  each: Validator;
+}
+
+export interface ChainOfValidator {
+  chainOf: Array<Validator>;
+}
+
+export interface OneOfValidator {
+  oneOf: Array<string | boolean | number>;
+}
+
+export interface OneOfNodeTypesValidator {
+  oneOfNodeTypes: Array<string>;
+}
+
+export interface OneOfNodeOrValueTypesValidator {
+  oneOfNodeOrValueTypes: Array<string>;
+}
+
+export interface Type {
+  type: string;
+}
+
+export type Validator =
+  | ArrayValidator
+  | ChainOfValidator
+  | OneOfValidator
+  | OneOfNodeTypesValidator
+  | OneOfNodeOrValueTypesValidator
+  | Type;
+
+export function isValidatorOfType(
+  type: string,
+  validator: Validator | undefined
+): boolean {
+  if (!validator) {
+    return false;
+  }
+
+  if ('chainOf' in validator) {
+    return validator.chainOf.some(child => isValidatorOfType(type, child));
+  }
+
+  if ('oneOf' in validator) {
+    return validator.oneOf.some(child => typeof child === type);
+  }
+
+  return 'type' in validator && validator.type === type;
+}
+
+export function typeFromName(name: string): t.TSType {
+  switch (name) {
+    case 'string':
+      return t.tsStringKeyword();
+    case 'number':
+      return t.tsNumberKeyword();
+    case 'boolean':
+      return t.tsBooleanKeyword();
+    case 'null':
+      return t.tsNullKeyword();
+    case 'undefined':
+      return t.tsUndefinedKeyword();
+    default:
+      return t.tsTypeReference(t.identifier(name));
+  }
+}
+
+export function typeForValidator(validator?: Validator): t.TSType {
+  if (!validator) {
+    return t.tsAnyKeyword();
+  }
+
+  if ('each' in validator) {
+    return t.tsArrayType(typeForValidator(validator.each));
+  }
+
+  if ('chainOf' in validator) {
+    return typeForValidator(validator.chainOf[1]);
+  }
+
+  if ('oneOf' in validator) {
+    return t.tsUnionType(
+      validator.oneOf.map(type => {
+        if (typeof type === 'string') {
+          return t.tsLiteralType(t.stringLiteral(type));
+        } else if (typeof type === 'boolean') {
+          return t.tsLiteralType(t.booleanLiteral(type));
+        } else if (typeof type === 'number') {
+          return t.tsLiteralType(t.numericLiteral(type));
+        } else {
+          throw new Error(`unexpected 'oneOf' value: ${type}`);
+        }
+      })
+    );
+  }
+
+  if ('oneOfNodeTypes' in validator) {
+    return t.tsUnionType(
+      validator.oneOfNodeTypes.map(type =>
+        t.tsTypeReference(t.identifier(type))
+      )
+    );
+  }
+
+  if ('oneOfNodeOrValueTypes' in validator) {
+    return t.tsUnionType(validator.oneOfNodeOrValueTypes.map(typeFromName));
+  }
+
+  if (validator.type) {
+    return typeFromName(validator.type);
+  }
+
+  return t.tsAnyKeyword();
+}
+
+function stringifyQualifiedName(type: t.TSQualifiedName): string {
+  if (t.isIdentifier(type.left)) {
+    return `${type.left.name}.${type.right.name}`;
+  } else {
+    return `${stringifyQualifiedName(type.left)}.${type.right.name}`;
+  }
+}
+
+export function stringifyType(
+  type: t.TSType,
+  replacer?: (type: t.TSType, value: string) => string | undefined
+): string {
+  function withReplacer(value: string): string {
+    return (replacer && replacer(type, value)) || value;
+  }
+
+  if (t.isTSUnionType(type)) {
+    return withReplacer(
+      type.types.map(child => stringifyType(child, replacer)).join(' | ')
+    );
+  } else if (t.isTSAnyKeyword(type)) {
+    return withReplacer('any');
+  } else if (t.isTSNumberKeyword(type)) {
+    return withReplacer('number');
+  } else if (t.isTSStringKeyword(type)) {
+    return withReplacer('string');
+  } else if (t.isTSUndefinedKeyword(type)) {
+    return withReplacer('undefined');
+  } else if (t.isTSTypeReference(type)) {
+    if (t.isIdentifier(type.typeName)) {
+      return withReplacer(type.typeName.name);
+    } else {
+      return withReplacer(stringifyQualifiedName(type.typeName));
+    }
+  } else if (t.isTSArrayType(type)) {
+    return withReplacer(`Array<${stringifyType(type.elementType, replacer)}>`);
+  } else {
+    return withReplacer(generate(type).code);
+  }
+}
+
+export function stringifyValidator(
+  validator: Validator | undefined,
+  nodePrefix: string,
+  nodeSuffix: string
+): string {
+  return stringifyType(typeForValidator(validator), (type, value) => {
+    if (t.isTSTypeReference(type)) {
+      return nodePrefix + value + nodeSuffix;
+    } else {
+      return value;
+    }
+  });
+}
+
+export function toFunctionName(typeName: string): string {
+  const _ = typeName.replace(/^TS/, 'ts').replace(/^JSX/, 'jsx');
+  return _.slice(0, 1).toLowerCase() + _.slice(1);
+}

--- a/packages/matchers/script/ci
+++ b/packages/matchers/script/ci
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+require('../../../script/_utils/runCommand')(
+  require.resolve('./_commands/ci.ts')
+);

--- a/packages/matchers/script/rebuild
+++ b/packages/matchers/script/rebuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+require('../../../script/_utils/runCommand')(
+  require.resolve('./_commands/rebuild.ts')
+);

--- a/packages/matchers/src/NodeTypes.ts
+++ b/packages/matchers/src/NodeTypes.ts
@@ -1,0 +1,34 @@
+import * as t from '@babel/types';
+import { Validator } from '../script/_utils/utils';
+
+export interface BuilderKeysByType {
+  [key: string]: Array<string>;
+}
+
+export interface NodeFieldsByType {
+  [key: string]: NodeFields;
+}
+
+export interface NodeFields {
+  [key: string]: NodeField;
+}
+
+export interface NodeField<T = unknown> {
+  default: T | null;
+  optional?: boolean;
+  validate: Validator;
+}
+
+export const { BUILDER_KEYS, NODE_FIELDS } = (t as unknown) as {
+  BUILDER_KEYS: BuilderKeysByType;
+  NODE_FIELDS: NodeFieldsByType;
+};
+
+export function isNode(value: unknown): value is t.Node {
+  return (
+    typeof value === 'object' &&
+    !!value &&
+    'type' in value &&
+    (value as { type: string }).type in NODE_FIELDS
+  );
+}

--- a/packages/matchers/src/__tests__/distributeAcrossSpacers.test.ts
+++ b/packages/matchers/src/__tests__/distributeAcrossSpacers.test.ts
@@ -1,0 +1,60 @@
+import distributeAcrossSpacers from '../utils/distributeAcrossSpacers';
+import { spacer, oneOrMore, zeroOrMore } from '../matchers/spacers';
+
+test('allocates nothing given an empty list of spacers', () => {
+  expect(Array.from(distributeAcrossSpacers([], 1))).toEqual([[]]);
+});
+
+test('allocates available to a single spacer within its bounds', () => {
+  expect(Array.from(distributeAcrossSpacers([spacer(0, 3)], 2))).toEqual([[2]]);
+  expect(Array.from(distributeAcrossSpacers([spacer(2, 4)], 3))).toEqual([[3]]);
+});
+
+test('allocates nothing if available is outside single spacer bounds', () => {
+  expect(Array.from(distributeAcrossSpacers([spacer(2, 4)], 1))).toEqual([]);
+  expect(Array.from(distributeAcrossSpacers([spacer(2, 4)], 5))).toEqual([]);
+});
+
+test('allocates a single space across multiple spacers', () => {
+  expect(
+    Array.from(distributeAcrossSpacers([spacer(0, 1), spacer(0, 1)], 1))
+  ).toEqual([[1, 0], [0, 1]]);
+});
+
+test('allocates multiple spaces across multiple spacers', () => {
+  expect(
+    Array.from(
+      distributeAcrossSpacers([spacer(1, 2), spacer(0, 1), spacer(2, 3)], 5)
+    )
+  ).toEqual([[2, 1, 2], [2, 0, 3], [1, 1, 3]]);
+});
+
+test('never allocates to empty spacers', () => {
+  expect(
+    Array.from(
+      distributeAcrossSpacers([spacer(0), spacer(0, 1), spacer(0, 1)], 1)
+    )
+  ).toEqual([[0, 1, 0], [0, 0, 1]]);
+});
+
+test('allocates correctly when spacers have no upper bound', () => {
+  expect(Array.from(distributeAcrossSpacers([zeroOrMore()], 2))).toEqual([[2]]);
+});
+
+test('allocates correctly with a trailing unbounded spacer', () => {
+  expect(
+    Array.from(
+      distributeAcrossSpacers([zeroOrMore(), spacer(), oneOrMore()], 1)
+    )
+  ).toEqual([]);
+  expect(
+    Array.from(
+      distributeAcrossSpacers([zeroOrMore(), spacer(), oneOrMore()], 2)
+    )
+  ).toEqual([[0, 1, 1]]);
+  expect(
+    Array.from(
+      distributeAcrossSpacers([zeroOrMore(), spacer(), oneOrMore()], 3)
+    )
+  ).toEqual([[1, 1, 1], [0, 1, 2]]);
+});

--- a/packages/matchers/src/__tests__/integration.test.ts
+++ b/packages/matchers/src/__tests__/integration.test.ts
@@ -1,0 +1,404 @@
+import * as t from '@babel/types';
+import * as m from '../../src/matchers';
+import js from './utils/parse/js';
+import generate from '@babel/generator';
+import traverse, { NodePath } from '@babel/traverse';
+import dedent = require('dedent');
+import { BuildExpression as E, BuildStatement as S } from './utils/builders';
+import match from '../utils/match';
+
+/**
+ * This test demonstrates using captures to extract parts of an AST for use in
+ * a codemod that unwraps unnecessary IIFEs. For example:
+ *
+ * ```js
+ * function iifeWithExpression() {
+ *   return (() => EXPR);
+ * }
+ *
+ * function iifeWithStatements() {
+ *   return (() => {
+ *     STMT1;
+ *     STMT2;
+ *   });
+ * }
+ *
+ * // becomes
+ *
+ * function iifeWithExpression() {
+ *   return EXPR;
+ * }
+ *
+ * function iifeWithStatements() {
+ *   STMT1;
+ *   STMT2;
+ * }
+ * ```
+ */
+test('codemod: unwrap unneeded IIFE', () => {
+  const ast = js(dedent`
+    function foo() {
+      return (() => 1)();
+    }
+  `);
+
+  let body: m.CapturedMatcher<t.Expression | t.BlockStatement>;
+
+  const returnedIIFEMatcher = m.returnStatement(
+    m.callExpression(m.function(
+      [],
+      (body = m.capture(m.or(m.anyExpression(), m.blockStatement())))
+    ) as m.Matcher<t.Expression>)
+  );
+
+  traverse(ast, {
+    ReturnStatement(path: NodePath<t.ReturnStatement>): void {
+      match(returnedIIFEMatcher, { body }, path.node, ({ body }) => {
+        if (t.isExpression(body)) {
+          path.replaceWith(t.returnStatement(body));
+        } else {
+          path.replaceWithMultiple(body.body);
+        }
+      });
+    }
+  });
+
+  expect(generate(ast).code).toEqual(dedent`
+    function foo() {
+      return 1;
+    }
+  `);
+});
+
+test('codemod: remove return labels', () => {
+  const ast = js(dedent`
+    function foo() {
+      console.log("calling foo");
+      let classlist;
+      console.log("about to return");
+      return (classlist = classes.join(" "));
+    }
+  `);
+  let labelDeclaration: m.CapturedMatcher<t.VariableDeclaration>;
+  let label: m.CapturedMatcher<string>;
+  let returnStatement: m.CapturedMatcher<t.ReturnStatement>;
+  let value: m.CapturedMatcher<t.Expression>;
+
+  const returnLabelFunctionMatcher = m.function(
+    undefined,
+    m.blockStatement(
+      m.anyList<t.Statement>(
+        m.zeroOrMore(),
+        (labelDeclaration = m.capture(
+          m.variableDeclaration(
+            'let',
+            m.oneOf(
+              m.variableDeclarator(
+                m.identifier((label = m.capture(m.anyString()))),
+                null
+              )
+            )
+          )
+        )),
+        m.zeroOrMore(),
+        (returnStatement = m.capture(
+          m.returnStatement(
+            m.assignmentExpression(
+              '=',
+              m.identifier(m.fromCapture(label)),
+              (value = m.capture())
+            )
+          )
+        )),
+        m.zeroOrMore()
+      )
+    )
+  );
+
+  function processFunction(path: NodePath<t.Function>): void {
+    match(
+      returnLabelFunctionMatcher,
+      { returnStatement, value, labelDeclaration },
+      path.node,
+      ({ returnStatement, value, labelDeclaration }) => {
+        const bodyPath = path.get('body');
+        if (bodyPath.isBlockStatement()) {
+          const labelDeclarationPath = bodyPath
+            .get('body')
+            .find(statementPath => statementPath.node === labelDeclaration);
+
+          if (labelDeclarationPath) {
+            labelDeclarationPath.remove();
+          }
+        }
+        returnStatement.argument = value;
+      }
+    );
+  }
+
+  traverse(ast, {
+    FunctionDeclaration: processFunction,
+    FunctionExpression: processFunction,
+    ArrowFunctionExpression: processFunction
+  });
+
+  expect(generate(ast).code).toEqual(dedent`
+    function foo() {
+      console.log("calling foo");
+      console.log("about to return");
+      return classes.join(" ");
+    }
+  `);
+});
+
+test('codemod: assert to jest expect', () => {
+  const ast = js(dedent`
+    assert.strictEqual(a, 7);
+    assert.deepEqual(b, {});
+    assert.ok(c);
+    assert.ok(!d);
+  `);
+
+  let actual: m.CapturedMatcher<t.Expression>;
+  let expected: m.CapturedMatcher<t.Expression>;
+  const assertEqualMatcher = m.callExpression(
+    m.memberExpression(
+      m.identifier('assert'),
+      m.identifier(m.or('strictEqual', 'deepEqual'))
+    ),
+    [
+      (actual = m.capture(m.anyExpression())),
+      (expected = m.capture(m.anyExpression()))
+    ]
+  );
+
+  let falsyValue: m.CapturedMatcher<t.Expression>;
+  const assertFalsyMatcher = m.callExpression(
+    m.memberExpression(m.identifier('assert'), m.identifier('ok')),
+    [m.unaryExpression('!', (falsyValue = m.capture(m.anyExpression())))]
+  );
+
+  let truthValue: m.CapturedMatcher<t.Expression>;
+  const assertTruthyMatcher = m.callExpression(
+    m.memberExpression(m.identifier('assert'), m.identifier('ok')),
+    [(truthValue = m.capture())]
+  );
+
+  traverse(ast, {
+    CallExpression(path: NodePath<t.CallExpression>): void {
+      // replace equality assertions
+      match(
+        assertEqualMatcher,
+        { actual, expected },
+        path.node,
+        ({ actual, expected }) => {
+          path.replaceWith(
+            t.callExpression(
+              t.memberExpression(
+                t.callExpression(t.identifier('expect'), [actual]),
+                t.identifier('toEqual')
+              ),
+              [expected]
+            )
+          );
+        }
+      );
+
+      // replace e.g. `assert.ok(!a)` with `expect(a).toBeFalsy()`
+      match(assertFalsyMatcher, { falsyValue }, path.node, ({ falsyValue }) => {
+        path.replaceWith(
+          t.callExpression(
+            t.memberExpression(
+              t.callExpression(t.identifier('expect'), [falsyValue]),
+              t.identifier('toBeFalsy')
+            ),
+            []
+          )
+        );
+      });
+
+      // replace e.g. `assert.ok(a)` with `expect(a).toBeTruthy()`
+      match(
+        assertTruthyMatcher,
+        { truthValue },
+        path.node,
+        ({ truthValue }) => {
+          path.replaceWith(
+            t.callExpression(
+              t.memberExpression(
+                t.callExpression(t.identifier('expect'), [truthValue]),
+                t.identifier('toBeTruthy')
+              ),
+              []
+            )
+          );
+        }
+      );
+    }
+  });
+
+  expect(generate(ast).code).toEqual(dedent`
+    expect(a).toEqual(7);
+    expect(b).toEqual({});
+    expect(c).toBeTruthy();
+    expect(d).toBeFalsy();
+  `);
+});
+
+test('codemod: double-equal null to triple-equal', () => {
+  const ast = js('a == null;');
+  const left = m.capture(m.identifier());
+  const eqeqNullMatcher = m.binaryExpression('==', left, m.nullLiteral());
+
+  traverse(ast, {
+    BinaryExpression(path: NodePath<t.BinaryExpression>): void {
+      match(eqeqNullMatcher, { left }, path.node, ({ left }) => {
+        path.replaceWith(E`${left} === null || ${left} === undefined`);
+      });
+    }
+  });
+
+  expect(generate(ast).code).toEqual('a === null || a === undefined;');
+});
+
+test('codemod: assert.expect to assert.async', () => {
+  const ast = js(dedent`
+    test("my test", function (assert) {
+      assert.expect(1);
+      window.server.get("/some/api", () => {
+        asyncThing().then(() => {
+          assert.ok(true, "API called!");
+        });
+      });
+      doStuff();
+    });
+  `);
+
+  // capture name of `assert` parameter
+  const assertBinding = m.capture(m.anyString());
+
+  // capture `assert.expect(<number>);` inside the async test
+  const assertExpect = m.capture(
+    m.expressionStatement(
+      m.callExpression(
+        m.memberExpression(
+          m.identifier(m.fromCapture(assertBinding)),
+          m.identifier('expect')
+        ),
+        [m.numericLiteral()]
+      )
+    )
+  );
+
+  // capture `assert.<method>(…);` inside the callback
+  const callbackAssertion = m.capture(
+    m.expressionStatement(
+      m.callExpression(
+        m.memberExpression(
+          m.identifier(m.fromCapture(assertBinding)),
+          m.identifier()
+        )
+      )
+    )
+  );
+
+  // capture callback function body
+  const callbackFunctionBody = m.containerOf(
+    m.blockStatement(
+      m.anyList(m.zeroOrMore(), callbackAssertion, m.zeroOrMore())
+    )
+  );
+
+  // capture async test function body
+  const asyncTestFunctionBody = m.capture(
+    m.blockStatement(
+      m.anyList(
+        m.zeroOrMore(),
+        assertExpect,
+        m.zeroOrMore(),
+        m.expressionStatement(
+          m.callExpression(
+            undefined,
+            m.anyList(
+              m.zeroOrMore(),
+              m.or(
+                m.functionExpression(
+                  undefined,
+                  undefined,
+                  callbackFunctionBody
+                ),
+                m.arrowFunctionExpression(undefined, callbackFunctionBody)
+              )
+            )
+          )
+        ),
+        m.zeroOrMore()
+      )
+    )
+  );
+
+  // match the whole `test('description', function(assert) { … })`
+  const asyncTestMatcher = m.callExpression(m.identifier('test'), [
+    m.stringLiteral(),
+    m.functionExpression(
+      undefined,
+      [m.identifier(assertBinding)],
+      asyncTestFunctionBody
+    )
+  ]);
+
+  traverse(ast, {
+    CallExpression(path: NodePath<t.CallExpression>): void {
+      match(
+        asyncTestMatcher,
+        {
+          asyncTestFunctionBody,
+          assertExpect,
+          callbackFunctionBody,
+          callbackAssertion,
+          assertBinding
+        },
+        path.node,
+        ({
+          asyncTestFunctionBody,
+          assertExpect,
+          callbackFunctionBody,
+          callbackAssertion,
+          assertBinding
+        }) => {
+          const assertExpectIndex = asyncTestFunctionBody.body.indexOf(
+            assertExpect
+          );
+          const callbackAssertionIndex = callbackFunctionBody.body.indexOf(
+            callbackAssertion
+          );
+
+          asyncTestFunctionBody.body.splice(
+            assertExpectIndex,
+            1,
+            S`const done = ${t.identifier(assertBinding)}.async();`
+          );
+
+          callbackFunctionBody.body.splice(
+            callbackAssertionIndex + 1,
+            0,
+            S`done();`
+          );
+        }
+      );
+    }
+  });
+
+  expect(generate(ast).code).toEqual(dedent`
+    test("my test", function (assert) {
+      const done = assert.async();
+      window.server.get("/some/api", () => {
+        asyncThing().then(() => {
+          assert.ok(true, "API called!");
+          done();
+        });
+      });
+      doStuff();
+    });
+  `);
+});

--- a/packages/matchers/src/__tests__/integration.test.ts
+++ b/packages/matchers/src/__tests__/integration.test.ts
@@ -402,3 +402,157 @@ test('codemod: assert.expect to assert.async', () => {
     });
   `);
 });
+
+test('codemod: convert static exported class to named exports', () => {
+  const className = m.capture(m.anyString());
+  const classDeclaration = m.capture(
+    m.classDeclaration(
+      m.identifier(className),
+      null,
+      m.classBody(
+        m.arrayOf(
+          m.classMethod(
+            'method',
+            m.identifier(),
+            m.anything(),
+            m.anything(),
+            false,
+            true
+          )
+        )
+      )
+    )
+  );
+  const exportDeclaration = m.capture(
+    m.exportDefaultDeclaration(m.identifier(m.fromCapture(className)))
+  );
+  const matcher = m.anyList<t.Statement>(
+    m.zeroOrMore(),
+    classDeclaration,
+    m.zeroOrMore(),
+    exportDeclaration,
+    m.zeroOrMore()
+  );
+
+  const thisPropertyAccessMatcher = m.memberExpression(
+    m.thisExpression(),
+    m.identifier(),
+    false
+  );
+
+  const ast = js(dedent`
+    class MobileAppUpsellHelper {
+      static getIosAppLink(specialTrackingLink) {
+        const trackingLink = specialTrackingLink || "IOS_BRANCH_LINK";
+        return this.getBranchLink(trackingLink);
+      }
+
+      static getAndroidAppLink(specialTrackingLink) {
+        const trackingLink = specialTrackingLink || "ANDROID_BRANCH_LINK";
+        return this.getBranchLink(trackingLink);
+      }
+
+      static getBranchLink(specialTrackingLink) {
+        if (specialTrackingLink && APP_DOWNLOAD_ASSETS[specialTrackingLink]) {
+          return APP_DOWNLOAD_ASSETS[specialTrackingLink];
+        }
+
+        return APP_DOWNLOAD_ASSETS.DEFAULT_BRANCH_LINK;
+      }
+
+      static getHideAppBanner() {
+        return CookieHelper.get("hide_app_banner");
+      }
+    }
+
+    export default MobileAppUpsellHelper;
+  `);
+
+  traverse(ast, {
+    Program(path: NodePath<t.Program>): void {
+      match(
+        matcher,
+        { exportDeclaration, classDeclaration },
+        path.node.body,
+        ({ exportDeclaration, classDeclaration }) => {
+          const statements = path.node.body;
+          const replacements: Array<t.Statement> = [];
+          const exportDeclarationPath = path.get('body')[
+            statements.indexOf(exportDeclaration)
+          ] as NodePath<t.ExportDefaultDeclaration>;
+          const classDeclarationPath = path.get('body')[
+            statements.indexOf(classDeclaration)
+          ] as NodePath<t.ClassDeclaration>;
+
+          for (const property of classDeclarationPath.get('body').get('body')) {
+            if (!property.isClassMethod()) {
+              throw new Error(
+                `unexpected ${property.type} while looking for ClassMethod`
+              );
+            }
+
+            if (!t.isIdentifier(property.node.key)) {
+              throw new Error(
+                `unexpected ${
+                  property.get('key').type
+                } while looking for Identifier`
+              );
+            }
+
+            replacements.push(
+              t.exportNamedDeclaration(
+                t.functionDeclaration(
+                  property.node.key,
+                  property.node.params,
+                  property.node.body,
+                  property.node.generator,
+                  property.node.async
+                ),
+                []
+              )
+            );
+
+            property.get('body').traverse({
+              enter(path: NodePath<t.Node>): void {
+                if (path.isFunction()) {
+                  if (!path.isArrowFunctionExpression()) {
+                    path.skip();
+                  }
+                } else if (
+                  path.isMemberExpression() &&
+                  thisPropertyAccessMatcher.match(path.node)
+                ) {
+                  path.replaceWith(path.node.property);
+                }
+              }
+            });
+          }
+
+          exportDeclarationPath.remove();
+          classDeclarationPath.replaceWithMultiple(replacements);
+        }
+      );
+    }
+  });
+
+  expect(generate(ast).code).toEqual(dedent`
+    export function getIosAppLink(specialTrackingLink) {
+      const trackingLink = specialTrackingLink || "IOS_BRANCH_LINK";
+      return getBranchLink(trackingLink);
+    }
+    export function getAndroidAppLink(specialTrackingLink) {
+      const trackingLink = specialTrackingLink || "ANDROID_BRANCH_LINK";
+      return getBranchLink(trackingLink);
+    }
+    export function getBranchLink(specialTrackingLink) {
+      if (specialTrackingLink && APP_DOWNLOAD_ASSETS[specialTrackingLink]) {
+        return APP_DOWNLOAD_ASSETS[specialTrackingLink];
+      }
+
+      return APP_DOWNLOAD_ASSETS.DEFAULT_BRANCH_LINK;
+    }
+    export function getHideAppBanner() {
+      return CookieHelper.get("hide_app_banner");
+    }
+  `);
+});

--- a/packages/matchers/src/__tests__/matchers.test.ts
+++ b/packages/matchers/src/__tests__/matchers.test.ts
@@ -264,13 +264,17 @@ test('containerOf captures the first matching value', () => {
   const plusMatcher = m.containerOf(m.binaryExpression('+'));
 
   expect(plusMatcher.match(js('console.log(a + b + c);'))).toBeTruthy();
-  expect(plusMatcher.current).toEqual(
-    t.binaryExpression(
+  expect({
+    currentKeys: plusMatcher.currentKeys,
+    current: plusMatcher.current
+  }).toEqual({
+    currentKeys: ['program', 'body', 0, 'expression', 'arguments', 0],
+    current: t.binaryExpression(
       '+',
       t.binaryExpression('+', t.identifier('a'), t.identifier('b')),
       t.identifier('c')
     )
-  );
+  });
 });
 
 test('matcher builds a matcher based on a predicate', () => {

--- a/packages/matchers/src/__tests__/matchers.test.ts
+++ b/packages/matchers/src/__tests__/matchers.test.ts
@@ -1,0 +1,290 @@
+import * as m from '../matchers';
+import * as t from '@babel/types';
+import js from './utils/parse/js';
+
+test('anyString matches strings', () => {
+  expect(m.anyString().match('')).toBeTruthy();
+  expect(m.anyString().match('abc')).toBeTruthy();
+  expect(m.anyString().match('hi\nthere')).toBeTruthy();
+  expect(m.anyString().match(new String('even this'))).toBeTruthy();
+
+  expect(m.anyString().match(0)).toBeFalsy();
+  expect(m.anyString().match(null)).toBeFalsy();
+  expect(m.anyString().match(undefined)).toBeFalsy();
+  expect(m.anyString().match([])).toBeFalsy();
+  expect(m.anyString().match({})).toBeFalsy();
+
+  // verify `match` acts as a type assertion
+  const value: unknown = undefined;
+  if (m.anyString().match(value)) {
+    () => value.toLowerCase();
+  }
+});
+
+test('anyNumber matches numbers', () => {
+  expect(m.anyNumber().match(0)).toBeTruthy();
+  expect(m.anyNumber().match(NaN)).toBeTruthy();
+  expect(m.anyNumber().match(new Number(1))).toBeTruthy();
+  expect(m.anyNumber().match(Infinity)).toBeTruthy();
+  expect(m.anyNumber().match(Number.MAX_VALUE)).toBeTruthy();
+
+  expect(m.anyNumber().match('string!?')).toBeFalsy();
+  expect(m.anyNumber().match(null)).toBeFalsy();
+  expect(m.anyNumber().match(undefined)).toBeFalsy();
+  expect(m.anyNumber().match([])).toBeFalsy();
+  expect(m.anyNumber().match({})).toBeFalsy();
+
+  // verify `match` acts as a type assertion
+  const value: unknown = undefined;
+  if (m.anyNumber().match(value)) {
+    () => value.toFixed();
+  }
+});
+
+test('anything matches everything', () => {
+  expect(m.anything().match(0)).toBeTruthy();
+  expect(m.anything().match('')).toBeTruthy();
+  expect(m.anything().match([])).toBeTruthy();
+  expect(m.anything().match({})).toBeTruthy();
+  expect(m.anything().match(() => {})).toBeTruthy();
+  expect(m.anything().match(null)).toBeTruthy();
+  expect(m.anything().match(undefined)).toBeTruthy();
+
+  // verify `match` acts as a type assertion
+  const value: unknown = undefined;
+  if (m.anything<number>().match(value)) {
+    () => value.toFixed();
+  }
+});
+
+test('arrayOf matches a variable-length homogenous array', () => {
+  expect(m.arrayOf(m.anyString()).match([])).toBeTruthy();
+  expect(m.arrayOf(m.anyString()).match(['a', 'b'])).toBeTruthy();
+  expect(m.arrayOf(m.arrayOf(m.anyString())).match([[], ['a']])).toBeTruthy();
+
+  expect(m.arrayOf(m.anyString()).match(['a', 1])).toBeFalsy();
+  expect(m.arrayOf(m.anyString()).match([0, 1])).toBeFalsy();
+
+  expect(m.arrayOf(m.anything()).match(null)).toBeFalsy();
+  expect(m.arrayOf(m.anything()).match(undefined)).toBeFalsy();
+  expect(m.arrayOf(m.anything()).match({})).toBeFalsy();
+  expect(m.arrayOf(m.anything()).match(() => {})).toBeFalsy();
+
+  // verify `match` acts as a type assertion
+  const value: unknown = undefined;
+  if (m.arrayOf(m.anyString()).match(value)) {
+    () => value.push('element');
+  }
+});
+
+test('tupleOf matches a fixed-length array', () => {
+  const stringNumberAnything = m.tupleOf<unknown>(
+    m.anyString(),
+    m.anyNumber(),
+    m.anything()
+  );
+
+  // happy path
+  expect(stringNumberAnything.match(['a', 1, {}])).toBeTruthy();
+
+  // out of order matchers
+  expect(stringNumberAnything.match([1, '', {}])).toBeFalsy();
+
+  // too few elements
+  expect(stringNumberAnything.match([])).toBeFalsy();
+
+  // too many elements
+  expect(stringNumberAnything.match(['a', 1, {}, []])).toBeFalsy();
+
+  // verify `match` acts as a type assertion
+  const value: unknown = undefined;
+  if (stringNumberAnything.match(value)) {
+    () => value.length;
+  }
+});
+
+test('oneOf matches a single-element array', () => {
+  expect(m.oneOf(m.anyString()).match([''])).toBeTruthy();
+  expect(m.oneOf(m.anything()).match([{}])).toBeTruthy();
+
+  expect(m.oneOf(m.anyString()).match(['', ''])).toBeFalsy();
+  expect(m.oneOf(m.anyString()).match([0])).toBeFalsy();
+  expect(m.oneOf(m.anyString()).match([])).toBeFalsy();
+});
+
+test('anyNode matches any known AST node type', () => {
+  expect(m.anyNode().match(t.identifier('abc'))).toBeTruthy();
+  expect(m.anyNode().match(t.program([]))).toBeTruthy();
+
+  expect(m.anyNode().match('Identifier')).toBeFalsy();
+  expect(m.anyNode().match(0)).toBeFalsy();
+  expect(m.anyNode().match({})).toBeFalsy();
+  expect(m.anyNode().match({ type: 'not a known type' })).toBeFalsy();
+  expect(m.anyNode().match(null)).toBeFalsy();
+  expect(m.anyNode().match(undefined)).toBeFalsy();
+});
+
+test('anyExpression matches any known AST expression node type', () => {
+  expect(m.anyExpression().match(t.identifier('abc'))).toBeTruthy();
+  expect(
+    m
+      .anyExpression()
+      .match(t.functionExpression(null, [], t.blockStatement([])))
+  ).toBeTruthy();
+
+  expect(m.anyExpression().match(t.file(t.program([]), [], []))).toBeFalsy();
+  expect(m.anyExpression().match(t.program([]))).toBeFalsy();
+  expect(m.anyExpression().match(t.emptyStatement())).toBeFalsy();
+  expect(m.anyExpression().match(t.returnStatement())).toBeFalsy();
+  expect(m.anyExpression().match(t.blockStatement([]))).toBeFalsy();
+});
+
+test('anyStatement matches any known AST statement node type', () => {
+  expect(m.anyStatement().match(t.emptyStatement())).toBeTruthy();
+  expect(m.anyStatement().match(t.returnStatement())).toBeTruthy();
+  expect(m.anyStatement().match(t.blockStatement([]))).toBeTruthy();
+
+  expect(m.anyStatement().match(t.thisExpression())).toBeFalsy();
+  expect(m.anyStatement().match(t.program([]))).toBeFalsy();
+  expect(m.anyStatement().match(t.file(t.program([]), [], []))).toBeFalsy();
+  expect(m.anyStatement().match(t.program([]))).toBeFalsy();
+});
+
+test('m.function( matches any known function node type', () => {
+  expect(
+    m.function().match(t.functionDeclaration(null, [], t.blockStatement([])))
+  ).toBeTruthy();
+  expect(
+    m.function().match(t.functionExpression(null, [], t.blockStatement([])))
+  ).toBeTruthy();
+  expect(
+    m.function().match(t.arrowFunctionExpression([], t.blockStatement([])))
+  ).toBeTruthy();
+
+  expect(m.function().match(t.thisExpression())).toBeFalsy();
+  expect(m.function().match(t.blockStatement([]))).toBeFalsy();
+});
+
+test('anyList reduces to tupleOf without any spacers', () => {
+  expect(m.anyList().match([])).toBeTruthy();
+  expect(
+    m.anyList<number | string>(m.anyString(), m.anyNumber()).match(['', 0])
+  ).toBeTruthy();
+});
+
+test('anyList with a fixed-width leading spacer', () => {
+  const list = m.anyList(m.spacer(), m.anyString());
+  expect(list.match([''])).toBeFalsy();
+  expect(list.match([{}, ''])).toBeTruthy();
+  expect(list.match([{}, {}, ''])).toBeFalsy();
+});
+
+test('anyList with a variable-width leading spacer', () => {
+  const list = m.anyList(m.spacer(0, 1), m.anyString());
+  expect(list.match([''])).toBeTruthy();
+  expect(list.match([{}, ''])).toBeTruthy();
+  expect(list.match([{}, {}, ''])).toBeFalsy();
+});
+
+test('anyList with a zero-width leading spacer', () => {
+  const list = m.anyList(m.spacer(0), m.anyString());
+  expect(list.match([''])).toBeTruthy();
+  expect(list.match([{}, ''])).toBeFalsy();
+  expect(list.match([{}, {}, ''])).toBeFalsy();
+});
+
+test('anyList with a fixed-width trailing spacer', () => {
+  const list = m.anyList(m.anyString(), m.spacer());
+  expect(list.match([''])).toBeFalsy();
+  expect(list.match(['', ''])).toBeTruthy();
+  expect(list.match(['', '', ''])).toBeFalsy();
+});
+
+test('anyList with multiple fixed spacers', () => {
+  const list = m.anyList<number | string>(
+    m.spacer(),
+    m.anyString(),
+    m.spacer(),
+    m.anyNumber(),
+    m.spacer()
+  );
+  expect(list.match([])).toBeFalsy();
+  expect(list.match([1, '', 2, 3, ''])).toBeTruthy();
+  expect(list.match([1, {}, 2, 3, ''])).toBeFalsy();
+});
+
+test('anyList with multiple dynamic spacers', () => {
+  const list = m.anyList<t.Statement>(
+    m.zeroOrMore(),
+    m.returnStatement(),
+    m.oneOrMore()
+  );
+  expect(list.match(js('return;').program.body)).toBeFalsy();
+  expect(list.match(js('return; foo();').program.body)).toBeTruthy();
+});
+
+test('or matches one of the values', () => {
+  expect(m.or().match(undefined)).toBeFalsy();
+  expect(m.or(m.anyString()).match('')).toBeTruthy();
+  expect(m.or(m.anyString(), m.anyNumber()).match(1)).toBeTruthy();
+  expect(m.or(m.anyString(), m.anyNumber()).match('')).toBeTruthy();
+  expect(m.or(m.anyString(), m.anyNumber(), null).match(null)).toBeTruthy();
+  expect(m.or(m.anyString(), m.anyNumber()).match({})).toBeFalsy();
+});
+
+test('or matches literal values', () => {
+  expect(m.or(1).match(1)).toBeTruthy();
+  expect(m.or(1, 2).match(1)).toBeTruthy();
+  expect(m.or(1, 2).match(2)).toBeTruthy();
+  expect(m.or(1, 2).match(3)).toBeFalsy();
+  expect(m.or(1, 2).match({})).toBeFalsy();
+});
+
+test('or matches mixed literal values and matchers', () => {
+  expect(m.or(1, m.anyString()).match(1)).toBeTruthy();
+  expect(m.or(1, m.anyString()).match('')).toBeTruthy();
+  expect(m.or(1, m.anyString()).match({})).toBeFalsy();
+});
+
+test('containerOf recurses to find a node matching the pattern', () => {
+  expect(
+    m
+      .containerOf(m.binaryExpression('+', m.identifier(), m.numericLiteral()))
+      .match(js('return a + 1'))
+  ).toBeTruthy();
+  expect(
+    m.containerOf(m.numericLiteral()).match(js('return a + 1'))
+  ).toBeTruthy();
+  expect(
+    m.containerOf(m.numericLiteral()).match(js('return a + b'))
+  ).toBeFalsy();
+});
+
+test('containerOf captures the first matching value', () => {
+  const plusMatcher = m.containerOf(m.binaryExpression('+'));
+
+  expect(plusMatcher.match(js('console.log(a + b + c);'))).toBeTruthy();
+  expect(plusMatcher.current).toEqual(
+    t.binaryExpression(
+      '+',
+      t.binaryExpression('+', t.identifier('a'), t.identifier('b')),
+      t.identifier('c')
+    )
+  );
+});
+
+test('matcher builds a matcher based on a predicate', () => {
+  const matcher = m.matcher(
+    value => typeof value === 'string' && value.startsWith('no')
+  );
+
+  expect(matcher.match('no')).toBeTruthy();
+  expect(matcher.match('nope')).toBeTruthy();
+  expect(matcher.match('no way')).toBeTruthy();
+  expect(matcher.match('notice')).toBeTruthy();
+
+  expect(matcher.match('')).toBeFalsy();
+  expect(matcher.match('another')).toBeFalsy();
+  expect(matcher.match({})).toBeFalsy();
+  expect(matcher.match(42)).toBeFalsy();
+});

--- a/packages/matchers/src/__tests__/matchers.test.ts
+++ b/packages/matchers/src/__tests__/matchers.test.ts
@@ -277,6 +277,20 @@ test('containerOf captures the first matching value', () => {
   });
 });
 
+test('containerOf can be used in a nested matcher', () => {
+  expect(
+    m
+      .containerOf(
+        m.functionDeclaration(
+          m.anything(),
+          m.anything(),
+          m.containerOf(m.thisExpression())
+        )
+      )
+      .match(js('function returnThis() { return this; }'))
+  ).toBeTruthy();
+});
+
 test('matcher builds a matcher based on a predicate', () => {
   const matcher = m.matcher(
     value => typeof value === 'string' && value.startsWith('no')

--- a/packages/matchers/src/__tests__/utils/builders.ts
+++ b/packages/matchers/src/__tests__/utils/builders.ts
@@ -1,0 +1,166 @@
+import * as t from '@babel/types';
+import * as m from '../../matchers';
+import { parse } from '@babel/parser';
+import traverse, { NodePath } from '@babel/traverse';
+import { Validator } from '../../../script/_utils/utils';
+import { isNode } from '../../NodeTypes';
+
+export type InterpolationValue =
+  | t.Statement
+  | t.Expression
+  | Array<t.Statement>
+  | Array<t.Expression>;
+
+export interface BuilderKeysByType {
+  [key: string]: Array<string>;
+}
+
+export interface NodeFieldsByType {
+  [key: string]: NodeFields;
+}
+
+export interface NodeFields {
+  [key: string]: NodeField;
+}
+
+export interface NodeField<T = unknown> {
+  default: T | null;
+  optional?: boolean;
+  validate: Validator;
+}
+
+const PLACEHOLDERS = new Map([
+  ['ArrayExpression', '[]'],
+  ['AssignmentExpression', '$LEFT$ = $RIGHT$'],
+  ['BlockStatement', '{}'],
+  ['BreakStatement', 'break;'],
+  ['BinaryExpression', '$LEFT$ == $RIGHT$'],
+  ['CallExpression', '$CALL$()'],
+  ['ContinueStatement', 'continue;'],
+  ['ConditionalExpression', '$TEST$ ? $CONSEQUENT$ : $ALTERNATE$'],
+  ['Directive', '"use strict";'],
+  ['DirectiveLiteral', '"use strict";'],
+  ['Identifier', '$IDENTIFIER$'],
+  ['NumericLiteral', '0'],
+  ['StringLiteral', '"$StringLiteral$"']
+]);
+
+export function access(
+  path: string
+): m.Matcher<t.MemberExpression | t.Identifier> {
+  const [first, ...rest] = path.split('.');
+  let result: m.Matcher<t.MemberExpression | t.Identifier> = m.identifier(
+    first
+  );
+
+  for (const property of rest) {
+    result = m.memberExpression(result, m.identifier(property));
+  }
+
+  return result;
+}
+
+export function addImport(
+  importDeclaration: t.ImportDeclaration
+): t.ImportDeclaration {
+  return importDeclaration;
+}
+
+export function BuildStatements<
+  R extends Array<t.Statement> = Array<t.Statement>
+>(quasis: TemplateStringsArray, ...values: Array<InterpolationValue>): R {
+  const offsetMap = new Map<number, InterpolationValue>();
+  let code = quasis[0];
+
+  for (let i = 0; i < values.length; i++) {
+    const nextValue = values[i];
+
+    if (isNode(nextValue)) {
+      const placeholder = PLACEHOLDERS.get(nextValue.type);
+
+      if (placeholder) {
+        offsetMap.set(code.length, nextValue);
+        code += placeholder;
+      } else {
+        throw new TypeError(
+          `unsupported interpolated node type ${nextValue.type}`
+        );
+      }
+    } else {
+      throw new TypeError(`unexpected interpolated value: ${nextValue}`);
+    }
+
+    code += quasis[i + 1];
+  }
+
+  const ast = parse(code, {
+    allowAwaitOutsideFunction: true,
+    allowImportExportEverywhere: true,
+    allowReturnOutsideFunction: true,
+    allowSuperOutsideMethod: true
+  });
+  const replaced = new Map<number, InterpolationValue>();
+
+  traverse(ast, {
+    enter(path: NodePath<t.Node>): void {
+      const start = path.node.start;
+      if (typeof start === 'number') {
+        const placeholder = offsetMap.get(start);
+        if (Array.isArray(placeholder)) {
+          replaced.set(start, placeholder);
+          path.replaceWithMultiple(placeholder);
+        } else if (placeholder && placeholder.type === path.node.type) {
+          replaced.set(start, placeholder);
+          path.replaceWith(placeholder);
+          return;
+        }
+      }
+    }
+  });
+
+  if (replaced.size !== offsetMap.size) {
+    throw new Error(
+      `replaced more or fewer values in matcher than expected: expected ${
+        offsetMap.size
+      }, replaced ${replaced.size}`
+    );
+  }
+
+  return ast.program.body as R;
+}
+
+export function BuildStatement<R extends t.Statement = t.Statement>(
+  quasis: TemplateStringsArray,
+  ...values: Array<InterpolationValue>
+): R {
+  const statements = BuildStatements(quasis, ...values);
+
+  if (statements.length !== 1) {
+    throw new TypeError(`expected a single statement but ${statements.length}`);
+  }
+
+  return statements[0] as R;
+}
+
+export function BuildExpression<R extends t.Expression = t.Expression>(
+  quasis: TemplateStringsArray,
+  ...values: Array<InterpolationValue>
+): R {
+  const statements = BuildStatements(quasis, ...values);
+
+  if (statements.length !== 1) {
+    throw new TypeError(
+      `expected a single expression but ${statements.length} statements`
+    );
+  }
+
+  const statement = statements[0];
+
+  if (!t.isExpressionStatement(statement)) {
+    throw new TypeError(
+      `expected a single expression but got a single ${statement.type}`
+    );
+  }
+
+  return statement.expression as R;
+}

--- a/packages/matchers/src/__tests__/utils/parse/js.ts
+++ b/packages/matchers/src/__tests__/utils/parse/js.ts
@@ -1,0 +1,48 @@
+import * as t from '@babel/types';
+import { parse } from '@babel/parser';
+import { NODE_FIELDS } from '../../../NodeTypes';
+
+function fieldsForNodeType(nodeType: string): Set<string> {
+  return new Set(['type', ...Object.keys(NODE_FIELDS[nodeType])]);
+}
+
+export default function js(code: string): t.File {
+  return stripExtras(
+    parse(code, {
+      allowAwaitOutsideFunction: true,
+      allowImportExportEverywhere: true,
+      allowReturnOutsideFunction: true,
+      allowSuperOutsideMethod: true
+    })
+  );
+}
+
+function stripExtras<N extends t.Node>(node: N): N {
+  const fieldsToKeep = fieldsForNodeType(node.type);
+  const allFields = Object.keys(node);
+
+  for (const field of allFields) {
+    // eslint-disable-next-line typescript/no-explicit-any
+    const nodeObj = node as any;
+
+    if (!fieldsToKeep.has(field)) {
+      delete nodeObj[field];
+    } else {
+      const children = Array.isArray(nodeObj[field])
+        ? nodeObj[field]
+        : [nodeObj[field]];
+
+      for (const child of children) {
+        if (
+          child &&
+          typeof child === 'object' &&
+          typeof child.type === 'string'
+        ) {
+          stripExtras(child);
+        }
+      }
+    }
+  }
+
+  return node;
+}

--- a/packages/matchers/src/index.ts
+++ b/packages/matchers/src/index.ts
@@ -1,2 +1,3 @@
 export * from './matchers';
 export { default as match } from './utils/match';
+export { default as matchPath } from './utils/matchPath';

--- a/packages/matchers/src/index.ts
+++ b/packages/matchers/src/index.ts
@@ -1,0 +1,2 @@
+export * from './matchers';
+export { default as match } from './utils/match';

--- a/packages/matchers/src/matchers.ts
+++ b/packages/matchers/src/matchers.ts
@@ -36,7 +36,7 @@ export class ArrayExpressionMatcher extends Matcher<t.ArrayExpression> {
     super();
   }
 
-  match(node: unknown): node is t.ArrayExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ArrayExpression {
     if (
       !isNode(node) ||
       !t.isArrayExpression(node)
@@ -47,10 +47,10 @@ export class ArrayExpressionMatcher extends Matcher<t.ArrayExpression> {
     if (typeof this.elements === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.elements)) {
-      if (!tupleOf<unknown>(...this.elements).match(node.elements)) {
+      if (!tupleOf<unknown>(...this.elements).matchValue(node.elements, [...keys, 'elements'])) {
         return false;
       }
-    } else if (!this.elements.match(node.elements)) {
+    } else if (!this.elements.matchValue(node.elements, [...keys, 'elements'])) {
       return false;
     }
 
@@ -75,7 +75,7 @@ export class AssignmentExpressionMatcher extends Matcher<t.AssignmentExpression>
     super();
   }
 
-  match(node: unknown): node is t.AssignmentExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.AssignmentExpression {
     if (
       !isNode(node) ||
       !t.isAssignmentExpression(node)
@@ -89,19 +89,19 @@ export class AssignmentExpressionMatcher extends Matcher<t.AssignmentExpression>
       if (this.operator !== node.operator) {
         return false;
       }
-    } else if (!this.operator.match(node.operator)) {
+    } else if (!this.operator.matchValue(node.operator, [...keys, 'operator'])) {
       return false;
     }
 
     if (typeof this.left === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.left.match(node.left)) {
+    } else if (!this.left.matchValue(node.left, [...keys, 'left'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
@@ -130,7 +130,7 @@ export class BinaryExpressionMatcher extends Matcher<t.BinaryExpression> {
     super();
   }
 
-  match(node: unknown): node is t.BinaryExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.BinaryExpression {
     if (
       !isNode(node) ||
       !t.isBinaryExpression(node)
@@ -144,19 +144,19 @@ export class BinaryExpressionMatcher extends Matcher<t.BinaryExpression> {
       if (this.operator !== node.operator) {
         return false;
       }
-    } else if (!this.operator.match(node.operator)) {
+    } else if (!this.operator.matchValue(node.operator, [...keys, 'operator'])) {
       return false;
     }
 
     if (typeof this.left === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.left.match(node.left)) {
+    } else if (!this.left.matchValue(node.left, [...keys, 'left'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
@@ -183,7 +183,7 @@ export class InterpreterDirectiveMatcher extends Matcher<t.InterpreterDirective>
     super();
   }
 
-  match(node: unknown): node is t.InterpreterDirective {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.InterpreterDirective {
     if (
       !isNode(node) ||
       !t.isInterpreterDirective(node)
@@ -197,7 +197,7 @@ export class InterpreterDirectiveMatcher extends Matcher<t.InterpreterDirective>
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -220,7 +220,7 @@ export class DirectiveMatcher extends Matcher<t.Directive> {
     super();
   }
 
-  match(node: unknown): node is t.Directive {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.Directive {
     if (
       !isNode(node) ||
       !t.isDirective(node)
@@ -230,7 +230,7 @@ export class DirectiveMatcher extends Matcher<t.Directive> {
 
     if (typeof this.value === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -253,7 +253,7 @@ export class DirectiveLiteralMatcher extends Matcher<t.DirectiveLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.DirectiveLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DirectiveLiteral {
     if (
       !isNode(node) ||
       !t.isDirectiveLiteral(node)
@@ -267,7 +267,7 @@ export class DirectiveLiteralMatcher extends Matcher<t.DirectiveLiteral> {
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -291,7 +291,7 @@ export class BlockStatementMatcher extends Matcher<t.BlockStatement> {
     super();
   }
 
-  match(node: unknown): node is t.BlockStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.BlockStatement {
     if (
       !isNode(node) ||
       !t.isBlockStatement(node)
@@ -302,20 +302,20 @@ export class BlockStatementMatcher extends Matcher<t.BlockStatement> {
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.body)) {
-      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+      if (!tupleOf<unknown>(...this.body).matchValue(node.body, [...keys, 'body'])) {
         return false;
       }
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
     if (typeof this.directives === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.directives)) {
-      if (!tupleOf<unknown>(...this.directives).match(node.directives)) {
+      if (!tupleOf<unknown>(...this.directives).matchValue(node.directives, [...keys, 'directives'])) {
         return false;
       }
-    } else if (!this.directives.match(node.directives)) {
+    } else if (!this.directives.matchValue(node.directives, [...keys, 'directives'])) {
       return false;
     }
 
@@ -340,7 +340,7 @@ export class BreakStatementMatcher extends Matcher<t.BreakStatement> {
     super();
   }
 
-  match(node: unknown): node is t.BreakStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.BreakStatement {
     if (
       !isNode(node) ||
       !t.isBreakStatement(node)
@@ -357,7 +357,7 @@ export class BreakStatementMatcher extends Matcher<t.BreakStatement> {
       }
     } else if (node.label === null) {
       return false;
-    } else if (!this.label.match(node.label)) {
+    } else if (!this.label.matchValue(node.label, [...keys, 'label'])) {
       return false;
     }
 
@@ -381,7 +381,7 @@ export class CallExpressionMatcher extends Matcher<t.CallExpression> {
     super();
   }
 
-  match(node: unknown): node is t.CallExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.CallExpression {
     if (
       !isNode(node) ||
       !t.isCallExpression(node)
@@ -391,17 +391,17 @@ export class CallExpressionMatcher extends Matcher<t.CallExpression> {
 
     if (typeof this.callee === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.callee.match(node.callee)) {
+    } else if (!this.callee.matchValue(node.callee, [...keys, 'callee'])) {
       return false;
     }
 
     if (typeof this._arguments === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this._arguments)) {
-      if (!tupleOf<unknown>(...this._arguments).match(node.arguments)) {
+      if (!tupleOf<unknown>(...this._arguments).matchValue(node.arguments, [...keys, 'arguments'])) {
         return false;
       }
-    } else if (!this._arguments.match(node.arguments)) {
+    } else if (!this._arguments.matchValue(node.arguments, [...keys, 'arguments'])) {
       return false;
     }
 
@@ -427,7 +427,7 @@ export class CatchClauseMatcher extends Matcher<t.CatchClause> {
     super();
   }
 
-  match(node: unknown): node is t.CatchClause {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.CatchClause {
     if (
       !isNode(node) ||
       !t.isCatchClause(node)
@@ -444,13 +444,13 @@ export class CatchClauseMatcher extends Matcher<t.CatchClause> {
       }
     } else if (node.param === null) {
       return false;
-    } else if (!this.param.match(node.param)) {
+    } else if (!this.param.matchValue(node.param, [...keys, 'param'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -477,7 +477,7 @@ export class ConditionalExpressionMatcher extends Matcher<t.ConditionalExpressio
     super();
   }
 
-  match(node: unknown): node is t.ConditionalExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ConditionalExpression {
     if (
       !isNode(node) ||
       !t.isConditionalExpression(node)
@@ -487,19 +487,19 @@ export class ConditionalExpressionMatcher extends Matcher<t.ConditionalExpressio
 
     if (typeof this.test === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.test.match(node.test)) {
+    } else if (!this.test.matchValue(node.test, [...keys, 'test'])) {
       return false;
     }
 
     if (typeof this.consequent === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.consequent.match(node.consequent)) {
+    } else if (!this.consequent.matchValue(node.consequent, [...keys, 'consequent'])) {
       return false;
     }
 
     if (typeof this.alternate === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.alternate.match(node.alternate)) {
+    } else if (!this.alternate.matchValue(node.alternate, [...keys, 'alternate'])) {
       return false;
     }
 
@@ -526,7 +526,7 @@ export class ContinueStatementMatcher extends Matcher<t.ContinueStatement> {
     super();
   }
 
-  match(node: unknown): node is t.ContinueStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ContinueStatement {
     if (
       !isNode(node) ||
       !t.isContinueStatement(node)
@@ -543,7 +543,7 @@ export class ContinueStatementMatcher extends Matcher<t.ContinueStatement> {
       }
     } else if (node.label === null) {
       return false;
-    } else if (!this.label.match(node.label)) {
+    } else if (!this.label.matchValue(node.label, [...keys, 'label'])) {
       return false;
     }
 
@@ -565,7 +565,7 @@ export class DebuggerStatementMatcher extends Matcher<t.DebuggerStatement> {
     super();
   }
 
-  match(node: unknown): node is t.DebuggerStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DebuggerStatement {
     if (
       !isNode(node) ||
       !t.isDebuggerStatement(node)
@@ -591,7 +591,7 @@ export class DoWhileStatementMatcher extends Matcher<t.DoWhileStatement> {
     super();
   }
 
-  match(node: unknown): node is t.DoWhileStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DoWhileStatement {
     if (
       !isNode(node) ||
       !t.isDoWhileStatement(node)
@@ -601,13 +601,13 @@ export class DoWhileStatementMatcher extends Matcher<t.DoWhileStatement> {
 
     if (typeof this.test === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.test.match(node.test)) {
+    } else if (!this.test.matchValue(node.test, [...keys, 'test'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -631,7 +631,7 @@ export class EmptyStatementMatcher extends Matcher<t.EmptyStatement> {
     super();
   }
 
-  match(node: unknown): node is t.EmptyStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.EmptyStatement {
     if (
       !isNode(node) ||
       !t.isEmptyStatement(node)
@@ -656,7 +656,7 @@ export class ExpressionStatementMatcher extends Matcher<t.ExpressionStatement> {
     super();
   }
 
-  match(node: unknown): node is t.ExpressionStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ExpressionStatement {
     if (
       !isNode(node) ||
       !t.isExpressionStatement(node)
@@ -666,7 +666,7 @@ export class ExpressionStatementMatcher extends Matcher<t.ExpressionStatement> {
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -691,7 +691,7 @@ export class FileMatcher extends Matcher<t.File> {
     super();
   }
 
-  match(node: unknown): node is t.File {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.File {
     if (
       !isNode(node) ||
       !t.isFile(node)
@@ -701,19 +701,19 @@ export class FileMatcher extends Matcher<t.File> {
 
     if (typeof this.program === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.program.match(node.program)) {
+    } else if (!this.program.matchValue(node.program, [...keys, 'program'])) {
       return false;
     }
 
     if (typeof this.comments === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.comments.match(node.comments)) {
+    } else if (!this.comments.matchValue(node.comments, [...keys, 'comments'])) {
       return false;
     }
 
     if (typeof this.tokens === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.tokens.match(node.tokens)) {
+    } else if (!this.tokens.matchValue(node.tokens, [...keys, 'tokens'])) {
       return false;
     }
 
@@ -742,7 +742,7 @@ export class ForInStatementMatcher extends Matcher<t.ForInStatement> {
     super();
   }
 
-  match(node: unknown): node is t.ForInStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ForInStatement {
     if (
       !isNode(node) ||
       !t.isForInStatement(node)
@@ -752,19 +752,19 @@ export class ForInStatementMatcher extends Matcher<t.ForInStatement> {
 
     if (typeof this.left === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.left.match(node.left)) {
+    } else if (!this.left.matchValue(node.left, [...keys, 'left'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -794,7 +794,7 @@ export class ForStatementMatcher extends Matcher<t.ForStatement> {
     super();
   }
 
-  match(node: unknown): node is t.ForStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ForStatement {
     if (
       !isNode(node) ||
       !t.isForStatement(node)
@@ -811,7 +811,7 @@ export class ForStatementMatcher extends Matcher<t.ForStatement> {
       }
     } else if (node.init === null) {
       return false;
-    } else if (!this.init.match(node.init)) {
+    } else if (!this.init.matchValue(node.init, [...keys, 'init'])) {
       return false;
     }
 
@@ -824,7 +824,7 @@ export class ForStatementMatcher extends Matcher<t.ForStatement> {
       }
     } else if (node.test === null) {
       return false;
-    } else if (!this.test.match(node.test)) {
+    } else if (!this.test.matchValue(node.test, [...keys, 'test'])) {
       return false;
     }
 
@@ -837,13 +837,13 @@ export class ForStatementMatcher extends Matcher<t.ForStatement> {
       }
     } else if (node.update === null) {
       return false;
-    } else if (!this.update.match(node.update)) {
+    } else if (!this.update.matchValue(node.update, [...keys, 'update'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -876,7 +876,7 @@ export class FunctionDeclarationMatcher extends Matcher<t.FunctionDeclaration> {
     super();
   }
 
-  match(node: unknown): node is t.FunctionDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.FunctionDeclaration {
     if (
       !isNode(node) ||
       !t.isFunctionDeclaration(node)
@@ -893,23 +893,23 @@ export class FunctionDeclarationMatcher extends Matcher<t.FunctionDeclaration> {
       }
     } else if (node.id === null) {
       return false;
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -926,7 +926,7 @@ export class FunctionDeclarationMatcher extends Matcher<t.FunctionDeclaration> {
       }
     } else if (node.generator === null) {
       return false;
-    } else if (!this.generator.match(node.generator)) {
+    } else if (!this.generator.matchValue(node.generator, [...keys, 'generator'])) {
       return false;
     }
 
@@ -943,7 +943,7 @@ export class FunctionDeclarationMatcher extends Matcher<t.FunctionDeclaration> {
       }
     } else if (node.async === null) {
       return false;
-    } else if (!this.async.match(node.async)) {
+    } else if (!this.async.matchValue(node.async, [...keys, 'async'])) {
       return false;
     }
 
@@ -978,7 +978,7 @@ export class FunctionExpressionMatcher extends Matcher<t.FunctionExpression> {
     super();
   }
 
-  match(node: unknown): node is t.FunctionExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.FunctionExpression {
     if (
       !isNode(node) ||
       !t.isFunctionExpression(node)
@@ -995,23 +995,23 @@ export class FunctionExpressionMatcher extends Matcher<t.FunctionExpression> {
       }
     } else if (node.id === null) {
       return false;
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -1028,7 +1028,7 @@ export class FunctionExpressionMatcher extends Matcher<t.FunctionExpression> {
       }
     } else if (node.generator === null) {
       return false;
-    } else if (!this.generator.match(node.generator)) {
+    } else if (!this.generator.matchValue(node.generator, [...keys, 'generator'])) {
       return false;
     }
 
@@ -1045,7 +1045,7 @@ export class FunctionExpressionMatcher extends Matcher<t.FunctionExpression> {
       }
     } else if (node.async === null) {
       return false;
-    } else if (!this.async.match(node.async)) {
+    } else if (!this.async.matchValue(node.async, [...keys, 'async'])) {
       return false;
     }
 
@@ -1076,7 +1076,7 @@ export class IdentifierMatcher extends Matcher<t.Identifier> {
     super();
   }
 
-  match(node: unknown): node is t.Identifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.Identifier {
     if (
       !isNode(node) ||
       !t.isIdentifier(node)
@@ -1090,7 +1090,7 @@ export class IdentifierMatcher extends Matcher<t.Identifier> {
       if (this.name !== node.name) {
         return false;
       }
-    } else if (!this.name.match(node.name)) {
+    } else if (!this.name.matchValue(node.name, [...keys, 'name'])) {
       return false;
     }
 
@@ -1115,7 +1115,7 @@ export class IfStatementMatcher extends Matcher<t.IfStatement> {
     super();
   }
 
-  match(node: unknown): node is t.IfStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.IfStatement {
     if (
       !isNode(node) ||
       !t.isIfStatement(node)
@@ -1125,13 +1125,13 @@ export class IfStatementMatcher extends Matcher<t.IfStatement> {
 
     if (typeof this.test === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.test.match(node.test)) {
+    } else if (!this.test.matchValue(node.test, [...keys, 'test'])) {
       return false;
     }
 
     if (typeof this.consequent === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.consequent.match(node.consequent)) {
+    } else if (!this.consequent.matchValue(node.consequent, [...keys, 'consequent'])) {
       return false;
     }
 
@@ -1144,7 +1144,7 @@ export class IfStatementMatcher extends Matcher<t.IfStatement> {
       }
     } else if (node.alternate === null) {
       return false;
-    } else if (!this.alternate.match(node.alternate)) {
+    } else if (!this.alternate.matchValue(node.alternate, [...keys, 'alternate'])) {
       return false;
     }
 
@@ -1172,7 +1172,7 @@ export class LabeledStatementMatcher extends Matcher<t.LabeledStatement> {
     super();
   }
 
-  match(node: unknown): node is t.LabeledStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.LabeledStatement {
     if (
       !isNode(node) ||
       !t.isLabeledStatement(node)
@@ -1182,13 +1182,13 @@ export class LabeledStatementMatcher extends Matcher<t.LabeledStatement> {
 
     if (typeof this.label === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.label.match(node.label)) {
+    } else if (!this.label.matchValue(node.label, [...keys, 'label'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -1213,7 +1213,7 @@ export class StringLiteralMatcher extends Matcher<t.StringLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.StringLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.StringLiteral {
     if (
       !isNode(node) ||
       !t.isStringLiteral(node)
@@ -1227,7 +1227,7 @@ export class StringLiteralMatcher extends Matcher<t.StringLiteral> {
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -1250,7 +1250,7 @@ export class NumericLiteralMatcher extends Matcher<t.NumericLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.NumericLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.NumericLiteral {
     if (
       !isNode(node) ||
       !t.isNumericLiteral(node)
@@ -1264,7 +1264,7 @@ export class NumericLiteralMatcher extends Matcher<t.NumericLiteral> {
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -1286,7 +1286,7 @@ export class NullLiteralMatcher extends Matcher<t.NullLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.NullLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.NullLiteral {
     if (
       !isNode(node) ||
       !t.isNullLiteral(node)
@@ -1311,7 +1311,7 @@ export class BooleanLiteralMatcher extends Matcher<t.BooleanLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.BooleanLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.BooleanLiteral {
     if (
       !isNode(node) ||
       !t.isBooleanLiteral(node)
@@ -1325,7 +1325,7 @@ export class BooleanLiteralMatcher extends Matcher<t.BooleanLiteral> {
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -1349,7 +1349,7 @@ export class RegExpLiteralMatcher extends Matcher<t.RegExpLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.RegExpLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.RegExpLiteral {
     if (
       !isNode(node) ||
       !t.isRegExpLiteral(node)
@@ -1363,7 +1363,7 @@ export class RegExpLiteralMatcher extends Matcher<t.RegExpLiteral> {
       if (this.pattern !== node.pattern) {
         return false;
       }
-    } else if (!this.pattern.match(node.pattern)) {
+    } else if (!this.pattern.matchValue(node.pattern, [...keys, 'pattern'])) {
       return false;
     }
 
@@ -1373,7 +1373,7 @@ export class RegExpLiteralMatcher extends Matcher<t.RegExpLiteral> {
       if (this.flags !== node.flags) {
         return false;
       }
-    } else if (!this.flags.match(node.flags)) {
+    } else if (!this.flags.matchValue(node.flags, [...keys, 'flags'])) {
       return false;
     }
 
@@ -1400,7 +1400,7 @@ export class LogicalExpressionMatcher extends Matcher<t.LogicalExpression> {
     super();
   }
 
-  match(node: unknown): node is t.LogicalExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.LogicalExpression {
     if (
       !isNode(node) ||
       !t.isLogicalExpression(node)
@@ -1414,19 +1414,19 @@ export class LogicalExpressionMatcher extends Matcher<t.LogicalExpression> {
       if (this.operator !== node.operator) {
         return false;
       }
-    } else if (!this.operator.match(node.operator)) {
+    } else if (!this.operator.matchValue(node.operator, [...keys, 'operator'])) {
       return false;
     }
 
     if (typeof this.left === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.left.match(node.left)) {
+    } else if (!this.left.matchValue(node.left, [...keys, 'left'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
@@ -1456,7 +1456,7 @@ export class MemberExpressionMatcher extends Matcher<t.MemberExpression> {
     super();
   }
 
-  match(node: unknown): node is t.MemberExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.MemberExpression {
     if (
       !isNode(node) ||
       !t.isMemberExpression(node)
@@ -1466,13 +1466,13 @@ export class MemberExpressionMatcher extends Matcher<t.MemberExpression> {
 
     if (typeof this.object === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.object.match(node.object)) {
+    } else if (!this.object.matchValue(node.object, [...keys, 'object'])) {
       return false;
     }
 
     if (typeof this.property === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.property.match(node.property)) {
+    } else if (!this.property.matchValue(node.property, [...keys, 'property'])) {
       return false;
     }
 
@@ -1482,7 +1482,7 @@ export class MemberExpressionMatcher extends Matcher<t.MemberExpression> {
       if (this.computed !== node.computed) {
         return false;
       }
-    } else if (!this.computed.match(node.computed)) {
+    } else if (!this.computed.matchValue(node.computed, [...keys, 'computed'])) {
       return false;
     }
 
@@ -1499,7 +1499,7 @@ export class MemberExpressionMatcher extends Matcher<t.MemberExpression> {
       }
     } else if (node.optional === null) {
       return false;
-    } else if (!this.optional.match(node.optional)) {
+    } else if (!this.optional.matchValue(node.optional, [...keys, 'optional'])) {
       return false;
     }
 
@@ -1529,7 +1529,7 @@ export class NewExpressionMatcher extends Matcher<t.NewExpression> {
     super();
   }
 
-  match(node: unknown): node is t.NewExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.NewExpression {
     if (
       !isNode(node) ||
       !t.isNewExpression(node)
@@ -1539,17 +1539,17 @@ export class NewExpressionMatcher extends Matcher<t.NewExpression> {
 
     if (typeof this.callee === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.callee.match(node.callee)) {
+    } else if (!this.callee.matchValue(node.callee, [...keys, 'callee'])) {
       return false;
     }
 
     if (typeof this._arguments === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this._arguments)) {
-      if (!tupleOf<unknown>(...this._arguments).match(node.arguments)) {
+      if (!tupleOf<unknown>(...this._arguments).matchValue(node.arguments, [...keys, 'arguments'])) {
         return false;
       }
-    } else if (!this._arguments.match(node.arguments)) {
+    } else if (!this._arguments.matchValue(node.arguments, [...keys, 'arguments'])) {
       return false;
     }
 
@@ -1577,7 +1577,7 @@ export class ProgramMatcher extends Matcher<t.Program> {
     super();
   }
 
-  match(node: unknown): node is t.Program {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.Program {
     if (
       !isNode(node) ||
       !t.isProgram(node)
@@ -1588,20 +1588,20 @@ export class ProgramMatcher extends Matcher<t.Program> {
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.body)) {
-      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+      if (!tupleOf<unknown>(...this.body).matchValue(node.body, [...keys, 'body'])) {
         return false;
       }
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
     if (typeof this.directives === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.directives)) {
-      if (!tupleOf<unknown>(...this.directives).match(node.directives)) {
+      if (!tupleOf<unknown>(...this.directives).matchValue(node.directives, [...keys, 'directives'])) {
         return false;
       }
-    } else if (!this.directives.match(node.directives)) {
+    } else if (!this.directives.matchValue(node.directives, [...keys, 'directives'])) {
       return false;
     }
 
@@ -1611,7 +1611,7 @@ export class ProgramMatcher extends Matcher<t.Program> {
       if (this.sourceType !== node.sourceType) {
         return false;
       }
-    } else if (!this.sourceType.match(node.sourceType)) {
+    } else if (!this.sourceType.matchValue(node.sourceType, [...keys, 'sourceType'])) {
       return false;
     }
 
@@ -1624,7 +1624,7 @@ export class ProgramMatcher extends Matcher<t.Program> {
       }
     } else if (node.interpreter === null) {
       return false;
-    } else if (!this.interpreter.match(node.interpreter)) {
+    } else if (!this.interpreter.matchValue(node.interpreter, [...keys, 'interpreter'])) {
       return false;
     }
 
@@ -1653,7 +1653,7 @@ export class ObjectExpressionMatcher extends Matcher<t.ObjectExpression> {
     super();
   }
 
-  match(node: unknown): node is t.ObjectExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectExpression {
     if (
       !isNode(node) ||
       !t.isObjectExpression(node)
@@ -1664,10 +1664,10 @@ export class ObjectExpressionMatcher extends Matcher<t.ObjectExpression> {
     if (typeof this.properties === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.properties)) {
-      if (!tupleOf<unknown>(...this.properties).match(node.properties)) {
+      if (!tupleOf<unknown>(...this.properties).matchValue(node.properties, [...keys, 'properties'])) {
         return false;
       }
-    } else if (!this.properties.match(node.properties)) {
+    } else if (!this.properties.matchValue(node.properties, [...keys, 'properties'])) {
       return false;
     }
 
@@ -1694,7 +1694,7 @@ export class ObjectMethodMatcher extends Matcher<t.ObjectMethod> {
     super();
   }
 
-  match(node: unknown): node is t.ObjectMethod {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectMethod {
     if (
       !isNode(node) ||
       !t.isObjectMethod(node)
@@ -1708,29 +1708,29 @@ export class ObjectMethodMatcher extends Matcher<t.ObjectMethod> {
       if (this.kind !== node.kind) {
         return false;
       }
-    } else if (!this.kind.match(node.kind)) {
+    } else if (!this.kind.matchValue(node.kind, [...keys, 'kind'])) {
       return false;
     }
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -1740,7 +1740,7 @@ export class ObjectMethodMatcher extends Matcher<t.ObjectMethod> {
       if (this.computed !== node.computed) {
         return false;
       }
-    } else if (!this.computed.match(node.computed)) {
+    } else if (!this.computed.matchValue(node.computed, [...keys, 'computed'])) {
       return false;
     }
 
@@ -1775,7 +1775,7 @@ export class ObjectPropertyMatcher extends Matcher<t.ObjectProperty> {
     super();
   }
 
-  match(node: unknown): node is t.ObjectProperty {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectProperty {
     if (
       !isNode(node) ||
       !t.isObjectProperty(node)
@@ -1785,13 +1785,13 @@ export class ObjectPropertyMatcher extends Matcher<t.ObjectProperty> {
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
     if (typeof this.value === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -1801,7 +1801,7 @@ export class ObjectPropertyMatcher extends Matcher<t.ObjectProperty> {
       if (this.computed !== node.computed) {
         return false;
       }
-    } else if (!this.computed.match(node.computed)) {
+    } else if (!this.computed.matchValue(node.computed, [...keys, 'computed'])) {
       return false;
     }
 
@@ -1811,7 +1811,7 @@ export class ObjectPropertyMatcher extends Matcher<t.ObjectProperty> {
       if (this.shorthand !== node.shorthand) {
         return false;
       }
-    } else if (!this.shorthand.match(node.shorthand)) {
+    } else if (!this.shorthand.matchValue(node.shorthand, [...keys, 'shorthand'])) {
       return false;
     }
 
@@ -1825,10 +1825,10 @@ export class ObjectPropertyMatcher extends Matcher<t.ObjectProperty> {
     } else if (node.decorators === null) {
       return false;
     } else if (Array.isArray(this.decorators)) {
-      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).matchValue(node.decorators, [...keys, 'decorators'])) {
         return false;
       }
-    } else if (!this.decorators.match(node.decorators)) {
+    } else if (!this.decorators.matchValue(node.decorators, [...keys, 'decorators'])) {
       return false;
     }
 
@@ -1859,7 +1859,7 @@ export class RestElementMatcher extends Matcher<t.RestElement> {
     super();
   }
 
-  match(node: unknown): node is t.RestElement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.RestElement {
     if (
       !isNode(node) ||
       !t.isRestElement(node)
@@ -1869,7 +1869,7 @@ export class RestElementMatcher extends Matcher<t.RestElement> {
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -1892,7 +1892,7 @@ export class ReturnStatementMatcher extends Matcher<t.ReturnStatement> {
     super();
   }
 
-  match(node: unknown): node is t.ReturnStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ReturnStatement {
     if (
       !isNode(node) ||
       !t.isReturnStatement(node)
@@ -1909,7 +1909,7 @@ export class ReturnStatementMatcher extends Matcher<t.ReturnStatement> {
       }
     } else if (node.argument === null) {
       return false;
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -1932,7 +1932,7 @@ export class SequenceExpressionMatcher extends Matcher<t.SequenceExpression> {
     super();
   }
 
-  match(node: unknown): node is t.SequenceExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.SequenceExpression {
     if (
       !isNode(node) ||
       !t.isSequenceExpression(node)
@@ -1943,10 +1943,10 @@ export class SequenceExpressionMatcher extends Matcher<t.SequenceExpression> {
     if (typeof this.expressions === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.expressions)) {
-      if (!tupleOf<unknown>(...this.expressions).match(node.expressions)) {
+      if (!tupleOf<unknown>(...this.expressions).matchValue(node.expressions, [...keys, 'expressions'])) {
         return false;
       }
-    } else if (!this.expressions.match(node.expressions)) {
+    } else if (!this.expressions.matchValue(node.expressions, [...keys, 'expressions'])) {
       return false;
     }
 
@@ -1970,7 +1970,7 @@ export class SwitchCaseMatcher extends Matcher<t.SwitchCase> {
     super();
   }
 
-  match(node: unknown): node is t.SwitchCase {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.SwitchCase {
     if (
       !isNode(node) ||
       !t.isSwitchCase(node)
@@ -1987,17 +1987,17 @@ export class SwitchCaseMatcher extends Matcher<t.SwitchCase> {
       }
     } else if (node.test === null) {
       return false;
-    } else if (!this.test.match(node.test)) {
+    } else if (!this.test.matchValue(node.test, [...keys, 'test'])) {
       return false;
     }
 
     if (typeof this.consequent === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.consequent)) {
-      if (!tupleOf<unknown>(...this.consequent).match(node.consequent)) {
+      if (!tupleOf<unknown>(...this.consequent).matchValue(node.consequent, [...keys, 'consequent'])) {
         return false;
       }
-    } else if (!this.consequent.match(node.consequent)) {
+    } else if (!this.consequent.matchValue(node.consequent, [...keys, 'consequent'])) {
       return false;
     }
 
@@ -2023,7 +2023,7 @@ export class SwitchStatementMatcher extends Matcher<t.SwitchStatement> {
     super();
   }
 
-  match(node: unknown): node is t.SwitchStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.SwitchStatement {
     if (
       !isNode(node) ||
       !t.isSwitchStatement(node)
@@ -2033,17 +2033,17 @@ export class SwitchStatementMatcher extends Matcher<t.SwitchStatement> {
 
     if (typeof this.discriminant === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.discriminant.match(node.discriminant)) {
+    } else if (!this.discriminant.matchValue(node.discriminant, [...keys, 'discriminant'])) {
       return false;
     }
 
     if (typeof this.cases === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.cases)) {
-      if (!tupleOf<unknown>(...this.cases).match(node.cases)) {
+      if (!tupleOf<unknown>(...this.cases).matchValue(node.cases, [...keys, 'cases'])) {
         return false;
       }
-    } else if (!this.cases.match(node.cases)) {
+    } else if (!this.cases.matchValue(node.cases, [...keys, 'cases'])) {
       return false;
     }
 
@@ -2067,7 +2067,7 @@ export class ThisExpressionMatcher extends Matcher<t.ThisExpression> {
     super();
   }
 
-  match(node: unknown): node is t.ThisExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ThisExpression {
     if (
       !isNode(node) ||
       !t.isThisExpression(node)
@@ -2092,7 +2092,7 @@ export class ThrowStatementMatcher extends Matcher<t.ThrowStatement> {
     super();
   }
 
-  match(node: unknown): node is t.ThrowStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ThrowStatement {
     if (
       !isNode(node) ||
       !t.isThrowStatement(node)
@@ -2102,7 +2102,7 @@ export class ThrowStatementMatcher extends Matcher<t.ThrowStatement> {
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -2127,7 +2127,7 @@ export class TryStatementMatcher extends Matcher<t.TryStatement> {
     super();
   }
 
-  match(node: unknown): node is t.TryStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TryStatement {
     if (
       !isNode(node) ||
       !t.isTryStatement(node)
@@ -2137,7 +2137,7 @@ export class TryStatementMatcher extends Matcher<t.TryStatement> {
 
     if (typeof this.block === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.block.match(node.block)) {
+    } else if (!this.block.matchValue(node.block, [...keys, 'block'])) {
       return false;
     }
 
@@ -2150,7 +2150,7 @@ export class TryStatementMatcher extends Matcher<t.TryStatement> {
       }
     } else if (node.handler === null) {
       return false;
-    } else if (!this.handler.match(node.handler)) {
+    } else if (!this.handler.matchValue(node.handler, [...keys, 'handler'])) {
       return false;
     }
 
@@ -2163,7 +2163,7 @@ export class TryStatementMatcher extends Matcher<t.TryStatement> {
       }
     } else if (node.finalizer === null) {
       return false;
-    } else if (!this.finalizer.match(node.finalizer)) {
+    } else if (!this.finalizer.matchValue(node.finalizer, [...keys, 'finalizer'])) {
       return false;
     }
 
@@ -2192,7 +2192,7 @@ export class UnaryExpressionMatcher extends Matcher<t.UnaryExpression> {
     super();
   }
 
-  match(node: unknown): node is t.UnaryExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.UnaryExpression {
     if (
       !isNode(node) ||
       !t.isUnaryExpression(node)
@@ -2206,13 +2206,13 @@ export class UnaryExpressionMatcher extends Matcher<t.UnaryExpression> {
       if (this.operator !== node.operator) {
         return false;
       }
-    } else if (!this.operator.match(node.operator)) {
+    } else if (!this.operator.matchValue(node.operator, [...keys, 'operator'])) {
       return false;
     }
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -2222,7 +2222,7 @@ export class UnaryExpressionMatcher extends Matcher<t.UnaryExpression> {
       if (this.prefix !== node.prefix) {
         return false;
       }
-    } else if (!this.prefix.match(node.prefix)) {
+    } else if (!this.prefix.matchValue(node.prefix, [...keys, 'prefix'])) {
       return false;
     }
 
@@ -2251,7 +2251,7 @@ export class UpdateExpressionMatcher extends Matcher<t.UpdateExpression> {
     super();
   }
 
-  match(node: unknown): node is t.UpdateExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.UpdateExpression {
     if (
       !isNode(node) ||
       !t.isUpdateExpression(node)
@@ -2265,13 +2265,13 @@ export class UpdateExpressionMatcher extends Matcher<t.UpdateExpression> {
       if (this.operator !== node.operator) {
         return false;
       }
-    } else if (!this.operator.match(node.operator)) {
+    } else if (!this.operator.matchValue(node.operator, [...keys, 'operator'])) {
       return false;
     }
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -2281,7 +2281,7 @@ export class UpdateExpressionMatcher extends Matcher<t.UpdateExpression> {
       if (this.prefix !== node.prefix) {
         return false;
       }
-    } else if (!this.prefix.match(node.prefix)) {
+    } else if (!this.prefix.matchValue(node.prefix, [...keys, 'prefix'])) {
       return false;
     }
 
@@ -2309,7 +2309,7 @@ export class VariableDeclarationMatcher extends Matcher<t.VariableDeclaration> {
     super();
   }
 
-  match(node: unknown): node is t.VariableDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.VariableDeclaration {
     if (
       !isNode(node) ||
       !t.isVariableDeclaration(node)
@@ -2323,17 +2323,17 @@ export class VariableDeclarationMatcher extends Matcher<t.VariableDeclaration> {
       if (this.kind !== node.kind) {
         return false;
       }
-    } else if (!this.kind.match(node.kind)) {
+    } else if (!this.kind.matchValue(node.kind, [...keys, 'kind'])) {
       return false;
     }
 
     if (typeof this.declarations === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.declarations)) {
-      if (!tupleOf<unknown>(...this.declarations).match(node.declarations)) {
+      if (!tupleOf<unknown>(...this.declarations).matchValue(node.declarations, [...keys, 'declarations'])) {
         return false;
       }
-    } else if (!this.declarations.match(node.declarations)) {
+    } else if (!this.declarations.matchValue(node.declarations, [...keys, 'declarations'])) {
       return false;
     }
 
@@ -2359,7 +2359,7 @@ export class VariableDeclaratorMatcher extends Matcher<t.VariableDeclarator> {
     super();
   }
 
-  match(node: unknown): node is t.VariableDeclarator {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.VariableDeclarator {
     if (
       !isNode(node) ||
       !t.isVariableDeclarator(node)
@@ -2369,7 +2369,7 @@ export class VariableDeclaratorMatcher extends Matcher<t.VariableDeclarator> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -2382,7 +2382,7 @@ export class VariableDeclaratorMatcher extends Matcher<t.VariableDeclarator> {
       }
     } else if (node.init === null) {
       return false;
-    } else if (!this.init.match(node.init)) {
+    } else if (!this.init.matchValue(node.init, [...keys, 'init'])) {
       return false;
     }
 
@@ -2408,7 +2408,7 @@ export class WhileStatementMatcher extends Matcher<t.WhileStatement> {
     super();
   }
 
-  match(node: unknown): node is t.WhileStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.WhileStatement {
     if (
       !isNode(node) ||
       !t.isWhileStatement(node)
@@ -2418,13 +2418,13 @@ export class WhileStatementMatcher extends Matcher<t.WhileStatement> {
 
     if (typeof this.test === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.test.match(node.test)) {
+    } else if (!this.test.matchValue(node.test, [...keys, 'test'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -2450,7 +2450,7 @@ export class WithStatementMatcher extends Matcher<t.WithStatement> {
     super();
   }
 
-  match(node: unknown): node is t.WithStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.WithStatement {
     if (
       !isNode(node) ||
       !t.isWithStatement(node)
@@ -2460,13 +2460,13 @@ export class WithStatementMatcher extends Matcher<t.WithStatement> {
 
     if (typeof this.object === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.object.match(node.object)) {
+    } else if (!this.object.matchValue(node.object, [...keys, 'object'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -2492,7 +2492,7 @@ export class AssignmentPatternMatcher extends Matcher<t.AssignmentPattern> {
     super();
   }
 
-  match(node: unknown): node is t.AssignmentPattern {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.AssignmentPattern {
     if (
       !isNode(node) ||
       !t.isAssignmentPattern(node)
@@ -2502,13 +2502,13 @@ export class AssignmentPatternMatcher extends Matcher<t.AssignmentPattern> {
 
     if (typeof this.left === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.left.match(node.left)) {
+    } else if (!this.left.matchValue(node.left, [...keys, 'left'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
@@ -2533,7 +2533,7 @@ export class ArrayPatternMatcher extends Matcher<t.ArrayPattern> {
     super();
   }
 
-  match(node: unknown): node is t.ArrayPattern {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ArrayPattern {
     if (
       !isNode(node) ||
       !t.isArrayPattern(node)
@@ -2544,10 +2544,10 @@ export class ArrayPatternMatcher extends Matcher<t.ArrayPattern> {
     if (typeof this.elements === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.elements)) {
-      if (!tupleOf<unknown>(...this.elements).match(node.elements)) {
+      if (!tupleOf<unknown>(...this.elements).matchValue(node.elements, [...keys, 'elements'])) {
         return false;
       }
-    } else if (!this.elements.match(node.elements)) {
+    } else if (!this.elements.matchValue(node.elements, [...keys, 'elements'])) {
       return false;
     }
 
@@ -2572,7 +2572,7 @@ export class ArrowFunctionExpressionMatcher extends Matcher<t.ArrowFunctionExpre
     super();
   }
 
-  match(node: unknown): node is t.ArrowFunctionExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ArrowFunctionExpression {
     if (
       !isNode(node) ||
       !t.isArrowFunctionExpression(node)
@@ -2583,16 +2583,16 @@ export class ArrowFunctionExpressionMatcher extends Matcher<t.ArrowFunctionExpre
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -2609,7 +2609,7 @@ export class ArrowFunctionExpressionMatcher extends Matcher<t.ArrowFunctionExpre
       }
     } else if (node.async === null) {
       return false;
-    } else if (!this.async.match(node.async)) {
+    } else if (!this.async.matchValue(node.async, [...keys, 'async'])) {
       return false;
     }
 
@@ -2636,7 +2636,7 @@ export class ClassBodyMatcher extends Matcher<t.ClassBody> {
     super();
   }
 
-  match(node: unknown): node is t.ClassBody {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ClassBody {
     if (
       !isNode(node) ||
       !t.isClassBody(node)
@@ -2647,10 +2647,10 @@ export class ClassBodyMatcher extends Matcher<t.ClassBody> {
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.body)) {
-      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+      if (!tupleOf<unknown>(...this.body).matchValue(node.body, [...keys, 'body'])) {
         return false;
       }
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -2676,7 +2676,7 @@ export class ClassDeclarationMatcher extends Matcher<t.ClassDeclaration> {
     super();
   }
 
-  match(node: unknown): node is t.ClassDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ClassDeclaration {
     if (
       !isNode(node) ||
       !t.isClassDeclaration(node)
@@ -2693,7 +2693,7 @@ export class ClassDeclarationMatcher extends Matcher<t.ClassDeclaration> {
       }
     } else if (node.id === null) {
       return false;
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -2706,13 +2706,13 @@ export class ClassDeclarationMatcher extends Matcher<t.ClassDeclaration> {
       }
     } else if (node.superClass === null) {
       return false;
-    } else if (!this.superClass.match(node.superClass)) {
+    } else if (!this.superClass.matchValue(node.superClass, [...keys, 'superClass'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -2726,10 +2726,10 @@ export class ClassDeclarationMatcher extends Matcher<t.ClassDeclaration> {
     } else if (node.decorators === null) {
       return false;
     } else if (Array.isArray(this.decorators)) {
-      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).matchValue(node.decorators, [...keys, 'decorators'])) {
         return false;
       }
-    } else if (!this.decorators.match(node.decorators)) {
+    } else if (!this.decorators.matchValue(node.decorators, [...keys, 'decorators'])) {
       return false;
     }
 
@@ -2761,7 +2761,7 @@ export class ClassExpressionMatcher extends Matcher<t.ClassExpression> {
     super();
   }
 
-  match(node: unknown): node is t.ClassExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ClassExpression {
     if (
       !isNode(node) ||
       !t.isClassExpression(node)
@@ -2778,7 +2778,7 @@ export class ClassExpressionMatcher extends Matcher<t.ClassExpression> {
       }
     } else if (node.id === null) {
       return false;
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -2791,13 +2791,13 @@ export class ClassExpressionMatcher extends Matcher<t.ClassExpression> {
       }
     } else if (node.superClass === null) {
       return false;
-    } else if (!this.superClass.match(node.superClass)) {
+    } else if (!this.superClass.matchValue(node.superClass, [...keys, 'superClass'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -2811,10 +2811,10 @@ export class ClassExpressionMatcher extends Matcher<t.ClassExpression> {
     } else if (node.decorators === null) {
       return false;
     } else if (Array.isArray(this.decorators)) {
-      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).matchValue(node.decorators, [...keys, 'decorators'])) {
         return false;
       }
-    } else if (!this.decorators.match(node.decorators)) {
+    } else if (!this.decorators.matchValue(node.decorators, [...keys, 'decorators'])) {
       return false;
     }
 
@@ -2843,7 +2843,7 @@ export class ExportAllDeclarationMatcher extends Matcher<t.ExportAllDeclaration>
     super();
   }
 
-  match(node: unknown): node is t.ExportAllDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ExportAllDeclaration {
     if (
       !isNode(node) ||
       !t.isExportAllDeclaration(node)
@@ -2853,7 +2853,7 @@ export class ExportAllDeclarationMatcher extends Matcher<t.ExportAllDeclaration>
 
     if (typeof this.source === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.source.match(node.source)) {
+    } else if (!this.source.matchValue(node.source, [...keys, 'source'])) {
       return false;
     }
 
@@ -2876,7 +2876,7 @@ export class ExportDefaultDeclarationMatcher extends Matcher<t.ExportDefaultDecl
     super();
   }
 
-  match(node: unknown): node is t.ExportDefaultDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ExportDefaultDeclaration {
     if (
       !isNode(node) ||
       !t.isExportDefaultDeclaration(node)
@@ -2886,7 +2886,7 @@ export class ExportDefaultDeclarationMatcher extends Matcher<t.ExportDefaultDecl
 
     if (typeof this.declaration === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.declaration.match(node.declaration)) {
+    } else if (!this.declaration.matchValue(node.declaration, [...keys, 'declaration'])) {
       return false;
     }
 
@@ -2911,7 +2911,7 @@ export class ExportNamedDeclarationMatcher extends Matcher<t.ExportNamedDeclarat
     super();
   }
 
-  match(node: unknown): node is t.ExportNamedDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ExportNamedDeclaration {
     if (
       !isNode(node) ||
       !t.isExportNamedDeclaration(node)
@@ -2928,17 +2928,17 @@ export class ExportNamedDeclarationMatcher extends Matcher<t.ExportNamedDeclarat
       }
     } else if (node.declaration === null) {
       return false;
-    } else if (!this.declaration.match(node.declaration)) {
+    } else if (!this.declaration.matchValue(node.declaration, [...keys, 'declaration'])) {
       return false;
     }
 
     if (typeof this.specifiers === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.specifiers)) {
-      if (!tupleOf<unknown>(...this.specifiers).match(node.specifiers)) {
+      if (!tupleOf<unknown>(...this.specifiers).matchValue(node.specifiers, [...keys, 'specifiers'])) {
         return false;
       }
-    } else if (!this.specifiers.match(node.specifiers)) {
+    } else if (!this.specifiers.matchValue(node.specifiers, [...keys, 'specifiers'])) {
       return false;
     }
 
@@ -2951,7 +2951,7 @@ export class ExportNamedDeclarationMatcher extends Matcher<t.ExportNamedDeclarat
       }
     } else if (node.source === null) {
       return false;
-    } else if (!this.source.match(node.source)) {
+    } else if (!this.source.matchValue(node.source, [...keys, 'source'])) {
       return false;
     }
 
@@ -2979,7 +2979,7 @@ export class ExportSpecifierMatcher extends Matcher<t.ExportSpecifier> {
     super();
   }
 
-  match(node: unknown): node is t.ExportSpecifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ExportSpecifier {
     if (
       !isNode(node) ||
       !t.isExportSpecifier(node)
@@ -2989,13 +2989,13 @@ export class ExportSpecifierMatcher extends Matcher<t.ExportSpecifier> {
 
     if (typeof this.local === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.local.match(node.local)) {
+    } else if (!this.local.matchValue(node.local, [...keys, 'local'])) {
       return false;
     }
 
     if (typeof this.exported === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.exported.match(node.exported)) {
+    } else if (!this.exported.matchValue(node.exported, [...keys, 'exported'])) {
       return false;
     }
 
@@ -3022,7 +3022,7 @@ export class ForOfStatementMatcher extends Matcher<t.ForOfStatement> {
     super();
   }
 
-  match(node: unknown): node is t.ForOfStatement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ForOfStatement {
     if (
       !isNode(node) ||
       !t.isForOfStatement(node)
@@ -3032,19 +3032,19 @@ export class ForOfStatementMatcher extends Matcher<t.ForOfStatement> {
 
     if (typeof this.left === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.left.match(node.left)) {
+    } else if (!this.left.matchValue(node.left, [...keys, 'left'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -3072,7 +3072,7 @@ export class ImportDeclarationMatcher extends Matcher<t.ImportDeclaration> {
     super();
   }
 
-  match(node: unknown): node is t.ImportDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ImportDeclaration {
     if (
       !isNode(node) ||
       !t.isImportDeclaration(node)
@@ -3083,16 +3083,16 @@ export class ImportDeclarationMatcher extends Matcher<t.ImportDeclaration> {
     if (typeof this.specifiers === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.specifiers)) {
-      if (!tupleOf<unknown>(...this.specifiers).match(node.specifiers)) {
+      if (!tupleOf<unknown>(...this.specifiers).matchValue(node.specifiers, [...keys, 'specifiers'])) {
         return false;
       }
-    } else if (!this.specifiers.match(node.specifiers)) {
+    } else if (!this.specifiers.matchValue(node.specifiers, [...keys, 'specifiers'])) {
       return false;
     }
 
     if (typeof this.source === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.source.match(node.source)) {
+    } else if (!this.source.matchValue(node.source, [...keys, 'source'])) {
       return false;
     }
 
@@ -3117,7 +3117,7 @@ export class ImportDefaultSpecifierMatcher extends Matcher<t.ImportDefaultSpecif
     super();
   }
 
-  match(node: unknown): node is t.ImportDefaultSpecifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ImportDefaultSpecifier {
     if (
       !isNode(node) ||
       !t.isImportDefaultSpecifier(node)
@@ -3127,7 +3127,7 @@ export class ImportDefaultSpecifierMatcher extends Matcher<t.ImportDefaultSpecif
 
     if (typeof this.local === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.local.match(node.local)) {
+    } else if (!this.local.matchValue(node.local, [...keys, 'local'])) {
       return false;
     }
 
@@ -3150,7 +3150,7 @@ export class ImportNamespaceSpecifierMatcher extends Matcher<t.ImportNamespaceSp
     super();
   }
 
-  match(node: unknown): node is t.ImportNamespaceSpecifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ImportNamespaceSpecifier {
     if (
       !isNode(node) ||
       !t.isImportNamespaceSpecifier(node)
@@ -3160,7 +3160,7 @@ export class ImportNamespaceSpecifierMatcher extends Matcher<t.ImportNamespaceSp
 
     if (typeof this.local === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.local.match(node.local)) {
+    } else if (!this.local.matchValue(node.local, [...keys, 'local'])) {
       return false;
     }
 
@@ -3184,7 +3184,7 @@ export class ImportSpecifierMatcher extends Matcher<t.ImportSpecifier> {
     super();
   }
 
-  match(node: unknown): node is t.ImportSpecifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ImportSpecifier {
     if (
       !isNode(node) ||
       !t.isImportSpecifier(node)
@@ -3194,13 +3194,13 @@ export class ImportSpecifierMatcher extends Matcher<t.ImportSpecifier> {
 
     if (typeof this.local === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.local.match(node.local)) {
+    } else if (!this.local.matchValue(node.local, [...keys, 'local'])) {
       return false;
     }
 
     if (typeof this.imported === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.imported.match(node.imported)) {
+    } else if (!this.imported.matchValue(node.imported, [...keys, 'imported'])) {
       return false;
     }
 
@@ -3226,7 +3226,7 @@ export class MetaPropertyMatcher extends Matcher<t.MetaProperty> {
     super();
   }
 
-  match(node: unknown): node is t.MetaProperty {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.MetaProperty {
     if (
       !isNode(node) ||
       !t.isMetaProperty(node)
@@ -3236,13 +3236,13 @@ export class MetaPropertyMatcher extends Matcher<t.MetaProperty> {
 
     if (typeof this.meta === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.meta.match(node.meta)) {
+    } else if (!this.meta.matchValue(node.meta, [...keys, 'meta'])) {
       return false;
     }
 
     if (typeof this.property === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.property.match(node.property)) {
+    } else if (!this.property.matchValue(node.property, [...keys, 'property'])) {
       return false;
     }
 
@@ -3272,7 +3272,7 @@ export class ClassMethodMatcher extends Matcher<t.ClassMethod> {
     super();
   }
 
-  match(node: unknown): node is t.ClassMethod {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ClassMethod {
     if (
       !isNode(node) ||
       !t.isClassMethod(node)
@@ -3293,29 +3293,29 @@ export class ClassMethodMatcher extends Matcher<t.ClassMethod> {
       }
     } else if (node.kind === null) {
       return false;
-    } else if (!this.kind.match(node.kind)) {
+    } else if (!this.kind.matchValue(node.kind, [...keys, 'kind'])) {
       return false;
     }
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -3332,7 +3332,7 @@ export class ClassMethodMatcher extends Matcher<t.ClassMethod> {
       }
     } else if (node.computed === null) {
       return false;
-    } else if (!this.computed.match(node.computed)) {
+    } else if (!this.computed.matchValue(node.computed, [...keys, 'computed'])) {
       return false;
     }
 
@@ -3349,7 +3349,7 @@ export class ClassMethodMatcher extends Matcher<t.ClassMethod> {
       }
     } else if (node.static === null) {
       return false;
-    } else if (!this._static.match(node.static)) {
+    } else if (!this._static.matchValue(node.static, [...keys, 'static'])) {
       return false;
     }
 
@@ -3382,7 +3382,7 @@ export class ObjectPatternMatcher extends Matcher<t.ObjectPattern> {
     super();
   }
 
-  match(node: unknown): node is t.ObjectPattern {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectPattern {
     if (
       !isNode(node) ||
       !t.isObjectPattern(node)
@@ -3393,10 +3393,10 @@ export class ObjectPatternMatcher extends Matcher<t.ObjectPattern> {
     if (typeof this.properties === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.properties)) {
-      if (!tupleOf<unknown>(...this.properties).match(node.properties)) {
+      if (!tupleOf<unknown>(...this.properties).matchValue(node.properties, [...keys, 'properties'])) {
         return false;
       }
-    } else if (!this.properties.match(node.properties)) {
+    } else if (!this.properties.matchValue(node.properties, [...keys, 'properties'])) {
       return false;
     }
 
@@ -3419,7 +3419,7 @@ export class SpreadElementMatcher extends Matcher<t.SpreadElement> {
     super();
   }
 
-  match(node: unknown): node is t.SpreadElement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.SpreadElement {
     if (
       !isNode(node) ||
       !t.isSpreadElement(node)
@@ -3429,7 +3429,7 @@ export class SpreadElementMatcher extends Matcher<t.SpreadElement> {
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -3451,7 +3451,7 @@ export class SuperMatcher extends Matcher<t.Super> {
     super();
   }
 
-  match(node: unknown): node is t.Super {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.Super {
     if (
       !isNode(node) ||
       !t.isSuper(node)
@@ -3477,7 +3477,7 @@ export class TaggedTemplateExpressionMatcher extends Matcher<t.TaggedTemplateExp
     super();
   }
 
-  match(node: unknown): node is t.TaggedTemplateExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TaggedTemplateExpression {
     if (
       !isNode(node) ||
       !t.isTaggedTemplateExpression(node)
@@ -3487,13 +3487,13 @@ export class TaggedTemplateExpressionMatcher extends Matcher<t.TaggedTemplateExp
 
     if (typeof this.tag === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.tag.match(node.tag)) {
+    } else if (!this.tag.matchValue(node.tag, [...keys, 'tag'])) {
       return false;
     }
 
     if (typeof this.quasi === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.quasi.match(node.quasi)) {
+    } else if (!this.quasi.matchValue(node.quasi, [...keys, 'quasi'])) {
       return false;
     }
 
@@ -3519,7 +3519,7 @@ export class TemplateElementMatcher extends Matcher<t.TemplateElement> {
     super();
   }
 
-  match(node: unknown): node is t.TemplateElement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TemplateElement {
     if (
       !isNode(node) ||
       !t.isTemplateElement(node)
@@ -3529,7 +3529,7 @@ export class TemplateElementMatcher extends Matcher<t.TemplateElement> {
 
     if (typeof this.value === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -3539,7 +3539,7 @@ export class TemplateElementMatcher extends Matcher<t.TemplateElement> {
       if (this.tail !== node.tail) {
         return false;
       }
-    } else if (!this.tail.match(node.tail)) {
+    } else if (!this.tail.matchValue(node.tail, [...keys, 'tail'])) {
       return false;
     }
 
@@ -3565,7 +3565,7 @@ export class TemplateLiteralMatcher extends Matcher<t.TemplateLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.TemplateLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TemplateLiteral {
     if (
       !isNode(node) ||
       !t.isTemplateLiteral(node)
@@ -3576,20 +3576,20 @@ export class TemplateLiteralMatcher extends Matcher<t.TemplateLiteral> {
     if (typeof this.quasis === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.quasis)) {
-      if (!tupleOf<unknown>(...this.quasis).match(node.quasis)) {
+      if (!tupleOf<unknown>(...this.quasis).matchValue(node.quasis, [...keys, 'quasis'])) {
         return false;
       }
-    } else if (!this.quasis.match(node.quasis)) {
+    } else if (!this.quasis.matchValue(node.quasis, [...keys, 'quasis'])) {
       return false;
     }
 
     if (typeof this.expressions === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.expressions)) {
-      if (!tupleOf<unknown>(...this.expressions).match(node.expressions)) {
+      if (!tupleOf<unknown>(...this.expressions).matchValue(node.expressions, [...keys, 'expressions'])) {
         return false;
       }
-    } else if (!this.expressions.match(node.expressions)) {
+    } else if (!this.expressions.matchValue(node.expressions, [...keys, 'expressions'])) {
       return false;
     }
 
@@ -3615,7 +3615,7 @@ export class YieldExpressionMatcher extends Matcher<t.YieldExpression> {
     super();
   }
 
-  match(node: unknown): node is t.YieldExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.YieldExpression {
     if (
       !isNode(node) ||
       !t.isYieldExpression(node)
@@ -3632,7 +3632,7 @@ export class YieldExpressionMatcher extends Matcher<t.YieldExpression> {
       }
     } else if (node.argument === null) {
       return false;
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -3642,7 +3642,7 @@ export class YieldExpressionMatcher extends Matcher<t.YieldExpression> {
       if (this.delegate !== node.delegate) {
         return false;
       }
-    } else if (!this.delegate.match(node.delegate)) {
+    } else if (!this.delegate.matchValue(node.delegate, [...keys, 'delegate'])) {
       return false;
     }
 
@@ -3666,7 +3666,7 @@ export class AnyTypeAnnotationMatcher extends Matcher<t.AnyTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.AnyTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.AnyTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isAnyTypeAnnotation(node)
@@ -3691,7 +3691,7 @@ export class ArrayTypeAnnotationMatcher extends Matcher<t.ArrayTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.ArrayTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ArrayTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isArrayTypeAnnotation(node)
@@ -3701,7 +3701,7 @@ export class ArrayTypeAnnotationMatcher extends Matcher<t.ArrayTypeAnnotation> {
 
     if (typeof this.elementType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.elementType.match(node.elementType)) {
+    } else if (!this.elementType.matchValue(node.elementType, [...keys, 'elementType'])) {
       return false;
     }
 
@@ -3723,7 +3723,7 @@ export class BooleanTypeAnnotationMatcher extends Matcher<t.BooleanTypeAnnotatio
     super();
   }
 
-  match(node: unknown): node is t.BooleanTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.BooleanTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isBooleanTypeAnnotation(node)
@@ -3748,7 +3748,7 @@ export class BooleanLiteralTypeAnnotationMatcher extends Matcher<t.BooleanLitera
     super();
   }
 
-  match(node: unknown): node is t.BooleanLiteralTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.BooleanLiteralTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isBooleanLiteralTypeAnnotation(node)
@@ -3762,7 +3762,7 @@ export class BooleanLiteralTypeAnnotationMatcher extends Matcher<t.BooleanLitera
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -3784,7 +3784,7 @@ export class NullLiteralTypeAnnotationMatcher extends Matcher<t.NullLiteralTypeA
     super();
   }
 
-  match(node: unknown): node is t.NullLiteralTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.NullLiteralTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isNullLiteralTypeAnnotation(node)
@@ -3810,7 +3810,7 @@ export class ClassImplementsMatcher extends Matcher<t.ClassImplements> {
     super();
   }
 
-  match(node: unknown): node is t.ClassImplements {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ClassImplements {
     if (
       !isNode(node) ||
       !t.isClassImplements(node)
@@ -3820,7 +3820,7 @@ export class ClassImplementsMatcher extends Matcher<t.ClassImplements> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -3833,7 +3833,7 @@ export class ClassImplementsMatcher extends Matcher<t.ClassImplements> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -3861,7 +3861,7 @@ export class DeclareClassMatcher extends Matcher<t.DeclareClass> {
     super();
   }
 
-  match(node: unknown): node is t.DeclareClass {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareClass {
     if (
       !isNode(node) ||
       !t.isDeclareClass(node)
@@ -3871,7 +3871,7 @@ export class DeclareClassMatcher extends Matcher<t.DeclareClass> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -3884,7 +3884,7 @@ export class DeclareClassMatcher extends Matcher<t.DeclareClass> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -3898,16 +3898,16 @@ export class DeclareClassMatcher extends Matcher<t.DeclareClass> {
     } else if (node.extends === null) {
       return false;
     } else if (Array.isArray(this._extends)) {
-      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+      if (!tupleOf<unknown>(...this._extends).matchValue(node.extends, [...keys, 'extends'])) {
         return false;
       }
-    } else if (!this._extends.match(node.extends)) {
+    } else if (!this._extends.matchValue(node.extends, [...keys, 'extends'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -3936,7 +3936,7 @@ export class DeclareFunctionMatcher extends Matcher<t.DeclareFunction> {
     super();
   }
 
-  match(node: unknown): node is t.DeclareFunction {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareFunction {
     if (
       !isNode(node) ||
       !t.isDeclareFunction(node)
@@ -3946,7 +3946,7 @@ export class DeclareFunctionMatcher extends Matcher<t.DeclareFunction> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -3972,7 +3972,7 @@ export class DeclareInterfaceMatcher extends Matcher<t.DeclareInterface> {
     super();
   }
 
-  match(node: unknown): node is t.DeclareInterface {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareInterface {
     if (
       !isNode(node) ||
       !t.isDeclareInterface(node)
@@ -3982,7 +3982,7 @@ export class DeclareInterfaceMatcher extends Matcher<t.DeclareInterface> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -3995,7 +3995,7 @@ export class DeclareInterfaceMatcher extends Matcher<t.DeclareInterface> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -4009,16 +4009,16 @@ export class DeclareInterfaceMatcher extends Matcher<t.DeclareInterface> {
     } else if (node.extends === null) {
       return false;
     } else if (Array.isArray(this._extends)) {
-      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+      if (!tupleOf<unknown>(...this._extends).matchValue(node.extends, [...keys, 'extends'])) {
         return false;
       }
-    } else if (!this._extends.match(node.extends)) {
+    } else if (!this._extends.matchValue(node.extends, [...keys, 'extends'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -4049,7 +4049,7 @@ export class DeclareModuleMatcher extends Matcher<t.DeclareModule> {
     super();
   }
 
-  match(node: unknown): node is t.DeclareModule {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareModule {
     if (
       !isNode(node) ||
       !t.isDeclareModule(node)
@@ -4059,13 +4059,13 @@ export class DeclareModuleMatcher extends Matcher<t.DeclareModule> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -4082,7 +4082,7 @@ export class DeclareModuleMatcher extends Matcher<t.DeclareModule> {
       }
     } else if (node.kind === null) {
       return false;
-    } else if (!this.kind.match(node.kind)) {
+    } else if (!this.kind.matchValue(node.kind, [...keys, 'kind'])) {
       return false;
     }
 
@@ -4109,7 +4109,7 @@ export class DeclareModuleExportsMatcher extends Matcher<t.DeclareModuleExports>
     super();
   }
 
-  match(node: unknown): node is t.DeclareModuleExports {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareModuleExports {
     if (
       !isNode(node) ||
       !t.isDeclareModuleExports(node)
@@ -4119,7 +4119,7 @@ export class DeclareModuleExportsMatcher extends Matcher<t.DeclareModuleExports>
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -4144,7 +4144,7 @@ export class DeclareTypeAliasMatcher extends Matcher<t.DeclareTypeAlias> {
     super();
   }
 
-  match(node: unknown): node is t.DeclareTypeAlias {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareTypeAlias {
     if (
       !isNode(node) ||
       !t.isDeclareTypeAlias(node)
@@ -4154,7 +4154,7 @@ export class DeclareTypeAliasMatcher extends Matcher<t.DeclareTypeAlias> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -4167,13 +4167,13 @@ export class DeclareTypeAliasMatcher extends Matcher<t.DeclareTypeAlias> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
@@ -4202,7 +4202,7 @@ export class DeclareOpaqueTypeMatcher extends Matcher<t.DeclareOpaqueType> {
     super();
   }
 
-  match(node: unknown): node is t.DeclareOpaqueType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareOpaqueType {
     if (
       !isNode(node) ||
       !t.isDeclareOpaqueType(node)
@@ -4212,7 +4212,7 @@ export class DeclareOpaqueTypeMatcher extends Matcher<t.DeclareOpaqueType> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -4225,7 +4225,7 @@ export class DeclareOpaqueTypeMatcher extends Matcher<t.DeclareOpaqueType> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -4238,7 +4238,7 @@ export class DeclareOpaqueTypeMatcher extends Matcher<t.DeclareOpaqueType> {
       }
     } else if (node.supertype === null) {
       return false;
-    } else if (!this.supertype.match(node.supertype)) {
+    } else if (!this.supertype.matchValue(node.supertype, [...keys, 'supertype'])) {
       return false;
     }
 
@@ -4265,7 +4265,7 @@ export class DeclareVariableMatcher extends Matcher<t.DeclareVariable> {
     super();
   }
 
-  match(node: unknown): node is t.DeclareVariable {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareVariable {
     if (
       !isNode(node) ||
       !t.isDeclareVariable(node)
@@ -4275,7 +4275,7 @@ export class DeclareVariableMatcher extends Matcher<t.DeclareVariable> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -4300,7 +4300,7 @@ export class DeclareExportDeclarationMatcher extends Matcher<t.DeclareExportDecl
     super();
   }
 
-  match(node: unknown): node is t.DeclareExportDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareExportDeclaration {
     if (
       !isNode(node) ||
       !t.isDeclareExportDeclaration(node)
@@ -4317,7 +4317,7 @@ export class DeclareExportDeclarationMatcher extends Matcher<t.DeclareExportDecl
       }
     } else if (node.declaration === null) {
       return false;
-    } else if (!this.declaration.match(node.declaration)) {
+    } else if (!this.declaration.matchValue(node.declaration, [...keys, 'declaration'])) {
       return false;
     }
 
@@ -4331,10 +4331,10 @@ export class DeclareExportDeclarationMatcher extends Matcher<t.DeclareExportDecl
     } else if (node.specifiers === null) {
       return false;
     } else if (Array.isArray(this.specifiers)) {
-      if (!tupleOf<unknown>(...this.specifiers).match(node.specifiers)) {
+      if (!tupleOf<unknown>(...this.specifiers).matchValue(node.specifiers, [...keys, 'specifiers'])) {
         return false;
       }
-    } else if (!this.specifiers.match(node.specifiers)) {
+    } else if (!this.specifiers.matchValue(node.specifiers, [...keys, 'specifiers'])) {
       return false;
     }
 
@@ -4347,7 +4347,7 @@ export class DeclareExportDeclarationMatcher extends Matcher<t.DeclareExportDecl
       }
     } else if (node.source === null) {
       return false;
-    } else if (!this.source.match(node.source)) {
+    } else if (!this.source.matchValue(node.source, [...keys, 'source'])) {
       return false;
     }
 
@@ -4374,7 +4374,7 @@ export class DeclareExportAllDeclarationMatcher extends Matcher<t.DeclareExportA
     super();
   }
 
-  match(node: unknown): node is t.DeclareExportAllDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclareExportAllDeclaration {
     if (
       !isNode(node) ||
       !t.isDeclareExportAllDeclaration(node)
@@ -4384,7 +4384,7 @@ export class DeclareExportAllDeclarationMatcher extends Matcher<t.DeclareExportA
 
     if (typeof this.source === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.source.match(node.source)) {
+    } else if (!this.source.matchValue(node.source, [...keys, 'source'])) {
       return false;
     }
 
@@ -4407,7 +4407,7 @@ export class DeclaredPredicateMatcher extends Matcher<t.DeclaredPredicate> {
     super();
   }
 
-  match(node: unknown): node is t.DeclaredPredicate {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DeclaredPredicate {
     if (
       !isNode(node) ||
       !t.isDeclaredPredicate(node)
@@ -4417,7 +4417,7 @@ export class DeclaredPredicateMatcher extends Matcher<t.DeclaredPredicate> {
 
     if (typeof this.value === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -4439,7 +4439,7 @@ export class ExistsTypeAnnotationMatcher extends Matcher<t.ExistsTypeAnnotation>
     super();
   }
 
-  match(node: unknown): node is t.ExistsTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ExistsTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isExistsTypeAnnotation(node)
@@ -4467,7 +4467,7 @@ export class FunctionTypeAnnotationMatcher extends Matcher<t.FunctionTypeAnnotat
     super();
   }
 
-  match(node: unknown): node is t.FunctionTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.FunctionTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isFunctionTypeAnnotation(node)
@@ -4484,17 +4484,17 @@ export class FunctionTypeAnnotationMatcher extends Matcher<t.FunctionTypeAnnotat
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
@@ -4507,13 +4507,13 @@ export class FunctionTypeAnnotationMatcher extends Matcher<t.FunctionTypeAnnotat
       }
     } else if (node.rest === null) {
       return false;
-    } else if (!this.rest.match(node.rest)) {
+    } else if (!this.rest.matchValue(node.rest, [...keys, 'rest'])) {
       return false;
     }
 
     if (typeof this.returnType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.returnType.match(node.returnType)) {
+    } else if (!this.returnType.matchValue(node.returnType, [...keys, 'returnType'])) {
       return false;
     }
 
@@ -4543,7 +4543,7 @@ export class FunctionTypeParamMatcher extends Matcher<t.FunctionTypeParam> {
     super();
   }
 
-  match(node: unknown): node is t.FunctionTypeParam {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.FunctionTypeParam {
     if (
       !isNode(node) ||
       !t.isFunctionTypeParam(node)
@@ -4560,13 +4560,13 @@ export class FunctionTypeParamMatcher extends Matcher<t.FunctionTypeParam> {
       }
     } else if (node.name === null) {
       return false;
-    } else if (!this.name.match(node.name)) {
+    } else if (!this.name.matchValue(node.name, [...keys, 'name'])) {
       return false;
     }
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -4592,7 +4592,7 @@ export class GenericTypeAnnotationMatcher extends Matcher<t.GenericTypeAnnotatio
     super();
   }
 
-  match(node: unknown): node is t.GenericTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.GenericTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isGenericTypeAnnotation(node)
@@ -4602,7 +4602,7 @@ export class GenericTypeAnnotationMatcher extends Matcher<t.GenericTypeAnnotatio
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -4615,7 +4615,7 @@ export class GenericTypeAnnotationMatcher extends Matcher<t.GenericTypeAnnotatio
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -4639,7 +4639,7 @@ export class InferredPredicateMatcher extends Matcher<t.InferredPredicate> {
     super();
   }
 
-  match(node: unknown): node is t.InferredPredicate {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.InferredPredicate {
     if (
       !isNode(node) ||
       !t.isInferredPredicate(node)
@@ -4665,7 +4665,7 @@ export class InterfaceExtendsMatcher extends Matcher<t.InterfaceExtends> {
     super();
   }
 
-  match(node: unknown): node is t.InterfaceExtends {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.InterfaceExtends {
     if (
       !isNode(node) ||
       !t.isInterfaceExtends(node)
@@ -4675,7 +4675,7 @@ export class InterfaceExtendsMatcher extends Matcher<t.InterfaceExtends> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -4688,7 +4688,7 @@ export class InterfaceExtendsMatcher extends Matcher<t.InterfaceExtends> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -4716,7 +4716,7 @@ export class InterfaceDeclarationMatcher extends Matcher<t.InterfaceDeclaration>
     super();
   }
 
-  match(node: unknown): node is t.InterfaceDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.InterfaceDeclaration {
     if (
       !isNode(node) ||
       !t.isInterfaceDeclaration(node)
@@ -4726,7 +4726,7 @@ export class InterfaceDeclarationMatcher extends Matcher<t.InterfaceDeclaration>
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -4739,7 +4739,7 @@ export class InterfaceDeclarationMatcher extends Matcher<t.InterfaceDeclaration>
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -4753,16 +4753,16 @@ export class InterfaceDeclarationMatcher extends Matcher<t.InterfaceDeclaration>
     } else if (node.extends === null) {
       return false;
     } else if (Array.isArray(this._extends)) {
-      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+      if (!tupleOf<unknown>(...this._extends).matchValue(node.extends, [...keys, 'extends'])) {
         return false;
       }
-    } else if (!this._extends.match(node.extends)) {
+    } else if (!this._extends.matchValue(node.extends, [...keys, 'extends'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -4792,7 +4792,7 @@ export class InterfaceTypeAnnotationMatcher extends Matcher<t.InterfaceTypeAnnot
     super();
   }
 
-  match(node: unknown): node is t.InterfaceTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.InterfaceTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isInterfaceTypeAnnotation(node)
@@ -4810,16 +4810,16 @@ export class InterfaceTypeAnnotationMatcher extends Matcher<t.InterfaceTypeAnnot
     } else if (node.extends === null) {
       return false;
     } else if (Array.isArray(this._extends)) {
-      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+      if (!tupleOf<unknown>(...this._extends).matchValue(node.extends, [...keys, 'extends'])) {
         return false;
       }
-    } else if (!this._extends.match(node.extends)) {
+    } else if (!this._extends.matchValue(node.extends, [...keys, 'extends'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -4844,7 +4844,7 @@ export class IntersectionTypeAnnotationMatcher extends Matcher<t.IntersectionTyp
     super();
   }
 
-  match(node: unknown): node is t.IntersectionTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.IntersectionTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isIntersectionTypeAnnotation(node)
@@ -4855,10 +4855,10 @@ export class IntersectionTypeAnnotationMatcher extends Matcher<t.IntersectionTyp
     if (typeof this.types === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.types)) {
-      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+      if (!tupleOf<unknown>(...this.types).matchValue(node.types, [...keys, 'types'])) {
         return false;
       }
-    } else if (!this.types.match(node.types)) {
+    } else if (!this.types.matchValue(node.types, [...keys, 'types'])) {
       return false;
     }
 
@@ -4880,7 +4880,7 @@ export class MixedTypeAnnotationMatcher extends Matcher<t.MixedTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.MixedTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.MixedTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isMixedTypeAnnotation(node)
@@ -4904,7 +4904,7 @@ export class EmptyTypeAnnotationMatcher extends Matcher<t.EmptyTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.EmptyTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.EmptyTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isEmptyTypeAnnotation(node)
@@ -4929,7 +4929,7 @@ export class NullableTypeAnnotationMatcher extends Matcher<t.NullableTypeAnnotat
     super();
   }
 
-  match(node: unknown): node is t.NullableTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.NullableTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isNullableTypeAnnotation(node)
@@ -4939,7 +4939,7 @@ export class NullableTypeAnnotationMatcher extends Matcher<t.NullableTypeAnnotat
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -4962,7 +4962,7 @@ export class NumberLiteralTypeAnnotationMatcher extends Matcher<t.NumberLiteralT
     super();
   }
 
-  match(node: unknown): node is t.NumberLiteralTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.NumberLiteralTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isNumberLiteralTypeAnnotation(node)
@@ -4976,7 +4976,7 @@ export class NumberLiteralTypeAnnotationMatcher extends Matcher<t.NumberLiteralT
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -4998,7 +4998,7 @@ export class NumberTypeAnnotationMatcher extends Matcher<t.NumberTypeAnnotation>
     super();
   }
 
-  match(node: unknown): node is t.NumberTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.NumberTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isNumberTypeAnnotation(node)
@@ -5027,7 +5027,7 @@ export class ObjectTypeAnnotationMatcher extends Matcher<t.ObjectTypeAnnotation>
     super();
   }
 
-  match(node: unknown): node is t.ObjectTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isObjectTypeAnnotation(node)
@@ -5038,10 +5038,10 @@ export class ObjectTypeAnnotationMatcher extends Matcher<t.ObjectTypeAnnotation>
     if (typeof this.properties === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.properties)) {
-      if (!tupleOf<unknown>(...this.properties).match(node.properties)) {
+      if (!tupleOf<unknown>(...this.properties).matchValue(node.properties, [...keys, 'properties'])) {
         return false;
       }
-    } else if (!this.properties.match(node.properties)) {
+    } else if (!this.properties.matchValue(node.properties, [...keys, 'properties'])) {
       return false;
     }
 
@@ -5055,10 +5055,10 @@ export class ObjectTypeAnnotationMatcher extends Matcher<t.ObjectTypeAnnotation>
     } else if (node.indexers === null) {
       return false;
     } else if (Array.isArray(this.indexers)) {
-      if (!tupleOf<unknown>(...this.indexers).match(node.indexers)) {
+      if (!tupleOf<unknown>(...this.indexers).matchValue(node.indexers, [...keys, 'indexers'])) {
         return false;
       }
-    } else if (!this.indexers.match(node.indexers)) {
+    } else if (!this.indexers.matchValue(node.indexers, [...keys, 'indexers'])) {
       return false;
     }
 
@@ -5072,10 +5072,10 @@ export class ObjectTypeAnnotationMatcher extends Matcher<t.ObjectTypeAnnotation>
     } else if (node.callProperties === null) {
       return false;
     } else if (Array.isArray(this.callProperties)) {
-      if (!tupleOf<unknown>(...this.callProperties).match(node.callProperties)) {
+      if (!tupleOf<unknown>(...this.callProperties).matchValue(node.callProperties, [...keys, 'callProperties'])) {
         return false;
       }
-    } else if (!this.callProperties.match(node.callProperties)) {
+    } else if (!this.callProperties.matchValue(node.callProperties, [...keys, 'callProperties'])) {
       return false;
     }
 
@@ -5089,10 +5089,10 @@ export class ObjectTypeAnnotationMatcher extends Matcher<t.ObjectTypeAnnotation>
     } else if (node.internalSlots === null) {
       return false;
     } else if (Array.isArray(this.internalSlots)) {
-      if (!tupleOf<unknown>(...this.internalSlots).match(node.internalSlots)) {
+      if (!tupleOf<unknown>(...this.internalSlots).matchValue(node.internalSlots, [...keys, 'internalSlots'])) {
         return false;
       }
-    } else if (!this.internalSlots.match(node.internalSlots)) {
+    } else if (!this.internalSlots.matchValue(node.internalSlots, [...keys, 'internalSlots'])) {
       return false;
     }
 
@@ -5102,7 +5102,7 @@ export class ObjectTypeAnnotationMatcher extends Matcher<t.ObjectTypeAnnotation>
       if (this.exact !== node.exact) {
         return false;
       }
-    } else if (!this.exact.match(node.exact)) {
+    } else if (!this.exact.matchValue(node.exact, [...keys, 'exact'])) {
       return false;
     }
 
@@ -5137,7 +5137,7 @@ export class ObjectTypeInternalSlotMatcher extends Matcher<t.ObjectTypeInternalS
     super();
   }
 
-  match(node: unknown): node is t.ObjectTypeInternalSlot {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectTypeInternalSlot {
     if (
       !isNode(node) ||
       !t.isObjectTypeInternalSlot(node)
@@ -5147,13 +5147,13 @@ export class ObjectTypeInternalSlotMatcher extends Matcher<t.ObjectTypeInternalS
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.value === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -5163,7 +5163,7 @@ export class ObjectTypeInternalSlotMatcher extends Matcher<t.ObjectTypeInternalS
       if (this.optional !== node.optional) {
         return false;
       }
-    } else if (!this.optional.match(node.optional)) {
+    } else if (!this.optional.matchValue(node.optional, [...keys, 'optional'])) {
       return false;
     }
 
@@ -5173,7 +5173,7 @@ export class ObjectTypeInternalSlotMatcher extends Matcher<t.ObjectTypeInternalS
       if (this._static !== node.static) {
         return false;
       }
-    } else if (!this._static.match(node.static)) {
+    } else if (!this._static.matchValue(node.static, [...keys, 'static'])) {
       return false;
     }
 
@@ -5183,7 +5183,7 @@ export class ObjectTypeInternalSlotMatcher extends Matcher<t.ObjectTypeInternalS
       if (this.method !== node.method) {
         return false;
       }
-    } else if (!this.method.match(node.method)) {
+    } else if (!this.method.matchValue(node.method, [...keys, 'method'])) {
       return false;
     }
 
@@ -5214,7 +5214,7 @@ export class ObjectTypeCallPropertyMatcher extends Matcher<t.ObjectTypeCallPrope
     super();
   }
 
-  match(node: unknown): node is t.ObjectTypeCallProperty {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectTypeCallProperty {
     if (
       !isNode(node) ||
       !t.isObjectTypeCallProperty(node)
@@ -5224,7 +5224,7 @@ export class ObjectTypeCallPropertyMatcher extends Matcher<t.ObjectTypeCallPrope
 
     if (typeof this.value === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -5250,7 +5250,7 @@ export class ObjectTypeIndexerMatcher extends Matcher<t.ObjectTypeIndexer> {
     super();
   }
 
-  match(node: unknown): node is t.ObjectTypeIndexer {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectTypeIndexer {
     if (
       !isNode(node) ||
       !t.isObjectTypeIndexer(node)
@@ -5267,19 +5267,19 @@ export class ObjectTypeIndexerMatcher extends Matcher<t.ObjectTypeIndexer> {
       }
     } else if (node.id === null) {
       return false;
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
     if (typeof this.value === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -5292,7 +5292,7 @@ export class ObjectTypeIndexerMatcher extends Matcher<t.ObjectTypeIndexer> {
       }
     } else if (node.variance === null) {
       return false;
-    } else if (!this.variance.match(node.variance)) {
+    } else if (!this.variance.matchValue(node.variance, [...keys, 'variance'])) {
       return false;
     }
 
@@ -5323,7 +5323,7 @@ export class ObjectTypePropertyMatcher extends Matcher<t.ObjectTypeProperty> {
     super();
   }
 
-  match(node: unknown): node is t.ObjectTypeProperty {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectTypeProperty {
     if (
       !isNode(node) ||
       !t.isObjectTypeProperty(node)
@@ -5333,13 +5333,13 @@ export class ObjectTypePropertyMatcher extends Matcher<t.ObjectTypeProperty> {
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
     if (typeof this.value === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -5352,7 +5352,7 @@ export class ObjectTypePropertyMatcher extends Matcher<t.ObjectTypeProperty> {
       }
     } else if (node.variance === null) {
       return false;
-    } else if (!this.variance.match(node.variance)) {
+    } else if (!this.variance.matchValue(node.variance, [...keys, 'variance'])) {
       return false;
     }
 
@@ -5379,7 +5379,7 @@ export class ObjectTypeSpreadPropertyMatcher extends Matcher<t.ObjectTypeSpreadP
     super();
   }
 
-  match(node: unknown): node is t.ObjectTypeSpreadProperty {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ObjectTypeSpreadProperty {
     if (
       !isNode(node) ||
       !t.isObjectTypeSpreadProperty(node)
@@ -5389,7 +5389,7 @@ export class ObjectTypeSpreadPropertyMatcher extends Matcher<t.ObjectTypeSpreadP
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -5415,7 +5415,7 @@ export class OpaqueTypeMatcher extends Matcher<t.OpaqueType> {
     super();
   }
 
-  match(node: unknown): node is t.OpaqueType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.OpaqueType {
     if (
       !isNode(node) ||
       !t.isOpaqueType(node)
@@ -5425,7 +5425,7 @@ export class OpaqueTypeMatcher extends Matcher<t.OpaqueType> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -5438,7 +5438,7 @@ export class OpaqueTypeMatcher extends Matcher<t.OpaqueType> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -5451,13 +5451,13 @@ export class OpaqueTypeMatcher extends Matcher<t.OpaqueType> {
       }
     } else if (node.supertype === null) {
       return false;
-    } else if (!this.supertype.match(node.supertype)) {
+    } else if (!this.supertype.matchValue(node.supertype, [...keys, 'supertype'])) {
       return false;
     }
 
     if (typeof this.impltype === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.impltype.match(node.impltype)) {
+    } else if (!this.impltype.matchValue(node.impltype, [...keys, 'impltype'])) {
       return false;
     }
 
@@ -5487,7 +5487,7 @@ export class QualifiedTypeIdentifierMatcher extends Matcher<t.QualifiedTypeIdent
     super();
   }
 
-  match(node: unknown): node is t.QualifiedTypeIdentifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.QualifiedTypeIdentifier {
     if (
       !isNode(node) ||
       !t.isQualifiedTypeIdentifier(node)
@@ -5497,13 +5497,13 @@ export class QualifiedTypeIdentifierMatcher extends Matcher<t.QualifiedTypeIdent
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.qualification === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.qualification.match(node.qualification)) {
+    } else if (!this.qualification.matchValue(node.qualification, [...keys, 'qualification'])) {
       return false;
     }
 
@@ -5528,7 +5528,7 @@ export class StringLiteralTypeAnnotationMatcher extends Matcher<t.StringLiteralT
     super();
   }
 
-  match(node: unknown): node is t.StringLiteralTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.StringLiteralTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isStringLiteralTypeAnnotation(node)
@@ -5542,7 +5542,7 @@ export class StringLiteralTypeAnnotationMatcher extends Matcher<t.StringLiteralT
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -5564,7 +5564,7 @@ export class StringTypeAnnotationMatcher extends Matcher<t.StringTypeAnnotation>
     super();
   }
 
-  match(node: unknown): node is t.StringTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.StringTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isStringTypeAnnotation(node)
@@ -5588,7 +5588,7 @@ export class ThisTypeAnnotationMatcher extends Matcher<t.ThisTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.ThisTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ThisTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isThisTypeAnnotation(node)
@@ -5613,7 +5613,7 @@ export class TupleTypeAnnotationMatcher extends Matcher<t.TupleTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.TupleTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TupleTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isTupleTypeAnnotation(node)
@@ -5624,10 +5624,10 @@ export class TupleTypeAnnotationMatcher extends Matcher<t.TupleTypeAnnotation> {
     if (typeof this.types === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.types)) {
-      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+      if (!tupleOf<unknown>(...this.types).matchValue(node.types, [...keys, 'types'])) {
         return false;
       }
-    } else if (!this.types.match(node.types)) {
+    } else if (!this.types.matchValue(node.types, [...keys, 'types'])) {
       return false;
     }
 
@@ -5650,7 +5650,7 @@ export class TypeofTypeAnnotationMatcher extends Matcher<t.TypeofTypeAnnotation>
     super();
   }
 
-  match(node: unknown): node is t.TypeofTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TypeofTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isTypeofTypeAnnotation(node)
@@ -5660,7 +5660,7 @@ export class TypeofTypeAnnotationMatcher extends Matcher<t.TypeofTypeAnnotation>
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -5685,7 +5685,7 @@ export class TypeAliasMatcher extends Matcher<t.TypeAlias> {
     super();
   }
 
-  match(node: unknown): node is t.TypeAlias {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TypeAlias {
     if (
       !isNode(node) ||
       !t.isTypeAlias(node)
@@ -5695,7 +5695,7 @@ export class TypeAliasMatcher extends Matcher<t.TypeAlias> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -5708,13 +5708,13 @@ export class TypeAliasMatcher extends Matcher<t.TypeAlias> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
@@ -5741,7 +5741,7 @@ export class TypeAnnotationMatcher extends Matcher<t.TypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.TypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TypeAnnotation {
     if (
       !isNode(node) ||
       !t.isTypeAnnotation(node)
@@ -5751,7 +5751,7 @@ export class TypeAnnotationMatcher extends Matcher<t.TypeAnnotation> {
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -5775,7 +5775,7 @@ export class TypeCastExpressionMatcher extends Matcher<t.TypeCastExpression> {
     super();
   }
 
-  match(node: unknown): node is t.TypeCastExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TypeCastExpression {
     if (
       !isNode(node) ||
       !t.isTypeCastExpression(node)
@@ -5785,13 +5785,13 @@ export class TypeCastExpressionMatcher extends Matcher<t.TypeCastExpression> {
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -5818,7 +5818,7 @@ export class TypeParameterMatcher extends Matcher<t.TypeParameter> {
     super();
   }
 
-  match(node: unknown): node is t.TypeParameter {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TypeParameter {
     if (
       !isNode(node) ||
       !t.isTypeParameter(node)
@@ -5835,7 +5835,7 @@ export class TypeParameterMatcher extends Matcher<t.TypeParameter> {
       }
     } else if (node.bound === null) {
       return false;
-    } else if (!this.bound.match(node.bound)) {
+    } else if (!this.bound.matchValue(node.bound, [...keys, 'bound'])) {
       return false;
     }
 
@@ -5848,7 +5848,7 @@ export class TypeParameterMatcher extends Matcher<t.TypeParameter> {
       }
     } else if (node.default === null) {
       return false;
-    } else if (!this._default.match(node.default)) {
+    } else if (!this._default.matchValue(node.default, [...keys, 'default'])) {
       return false;
     }
 
@@ -5861,7 +5861,7 @@ export class TypeParameterMatcher extends Matcher<t.TypeParameter> {
       }
     } else if (node.variance === null) {
       return false;
-    } else if (!this.variance.match(node.variance)) {
+    } else if (!this.variance.matchValue(node.variance, [...keys, 'variance'])) {
       return false;
     }
 
@@ -5888,7 +5888,7 @@ export class TypeParameterDeclarationMatcher extends Matcher<t.TypeParameterDecl
     super();
   }
 
-  match(node: unknown): node is t.TypeParameterDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TypeParameterDeclaration {
     if (
       !isNode(node) ||
       !t.isTypeParameterDeclaration(node)
@@ -5899,10 +5899,10 @@ export class TypeParameterDeclarationMatcher extends Matcher<t.TypeParameterDecl
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
@@ -5925,7 +5925,7 @@ export class TypeParameterInstantiationMatcher extends Matcher<t.TypeParameterIn
     super();
   }
 
-  match(node: unknown): node is t.TypeParameterInstantiation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TypeParameterInstantiation {
     if (
       !isNode(node) ||
       !t.isTypeParameterInstantiation(node)
@@ -5936,10 +5936,10 @@ export class TypeParameterInstantiationMatcher extends Matcher<t.TypeParameterIn
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
@@ -5962,7 +5962,7 @@ export class UnionTypeAnnotationMatcher extends Matcher<t.UnionTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.UnionTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.UnionTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isUnionTypeAnnotation(node)
@@ -5973,10 +5973,10 @@ export class UnionTypeAnnotationMatcher extends Matcher<t.UnionTypeAnnotation> {
     if (typeof this.types === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.types)) {
-      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+      if (!tupleOf<unknown>(...this.types).matchValue(node.types, [...keys, 'types'])) {
         return false;
       }
-    } else if (!this.types.match(node.types)) {
+    } else if (!this.types.matchValue(node.types, [...keys, 'types'])) {
       return false;
     }
 
@@ -5999,7 +5999,7 @@ export class VarianceMatcher extends Matcher<t.Variance> {
     super();
   }
 
-  match(node: unknown): node is t.Variance {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.Variance {
     if (
       !isNode(node) ||
       !t.isVariance(node)
@@ -6013,7 +6013,7 @@ export class VarianceMatcher extends Matcher<t.Variance> {
       if (this.kind !== node.kind) {
         return false;
       }
-    } else if (!this.kind.match(node.kind)) {
+    } else if (!this.kind.matchValue(node.kind, [...keys, 'kind'])) {
       return false;
     }
 
@@ -6035,7 +6035,7 @@ export class VoidTypeAnnotationMatcher extends Matcher<t.VoidTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.VoidTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.VoidTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isVoidTypeAnnotation(node)
@@ -6061,7 +6061,7 @@ export class JSXAttributeMatcher extends Matcher<t.JSXAttribute> {
     super();
   }
 
-  match(node: unknown): node is t.JSXAttribute {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXAttribute {
     if (
       !isNode(node) ||
       !t.isJSXAttribute(node)
@@ -6071,7 +6071,7 @@ export class JSXAttributeMatcher extends Matcher<t.JSXAttribute> {
 
     if (typeof this.name === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.name.match(node.name)) {
+    } else if (!this.name.matchValue(node.name, [...keys, 'name'])) {
       return false;
     }
 
@@ -6084,7 +6084,7 @@ export class JSXAttributeMatcher extends Matcher<t.JSXAttribute> {
       }
     } else if (node.value === null) {
       return false;
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -6109,7 +6109,7 @@ export class JSXClosingElementMatcher extends Matcher<t.JSXClosingElement> {
     super();
   }
 
-  match(node: unknown): node is t.JSXClosingElement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXClosingElement {
     if (
       !isNode(node) ||
       !t.isJSXClosingElement(node)
@@ -6119,7 +6119,7 @@ export class JSXClosingElementMatcher extends Matcher<t.JSXClosingElement> {
 
     if (typeof this.name === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.name.match(node.name)) {
+    } else if (!this.name.matchValue(node.name, [...keys, 'name'])) {
       return false;
     }
 
@@ -6145,7 +6145,7 @@ export class JSXElementMatcher extends Matcher<t.JSXElement> {
     super();
   }
 
-  match(node: unknown): node is t.JSXElement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXElement {
     if (
       !isNode(node) ||
       !t.isJSXElement(node)
@@ -6155,7 +6155,7 @@ export class JSXElementMatcher extends Matcher<t.JSXElement> {
 
     if (typeof this.openingElement === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.openingElement.match(node.openingElement)) {
+    } else if (!this.openingElement.matchValue(node.openingElement, [...keys, 'openingElement'])) {
       return false;
     }
 
@@ -6168,23 +6168,23 @@ export class JSXElementMatcher extends Matcher<t.JSXElement> {
       }
     } else if (node.closingElement === null) {
       return false;
-    } else if (!this.closingElement.match(node.closingElement)) {
+    } else if (!this.closingElement.matchValue(node.closingElement, [...keys, 'closingElement'])) {
       return false;
     }
 
     if (typeof this.children === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.children)) {
-      if (!tupleOf<unknown>(...this.children).match(node.children)) {
+      if (!tupleOf<unknown>(...this.children).matchValue(node.children, [...keys, 'children'])) {
         return false;
       }
-    } else if (!this.children.match(node.children)) {
+    } else if (!this.children.matchValue(node.children, [...keys, 'children'])) {
       return false;
     }
 
     if (typeof this.selfClosing === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.selfClosing.match(node.selfClosing)) {
+    } else if (!this.selfClosing.matchValue(node.selfClosing, [...keys, 'selfClosing'])) {
       return false;
     }
 
@@ -6212,7 +6212,7 @@ export class JSXEmptyExpressionMatcher extends Matcher<t.JSXEmptyExpression> {
     super();
   }
 
-  match(node: unknown): node is t.JSXEmptyExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXEmptyExpression {
     if (
       !isNode(node) ||
       !t.isJSXEmptyExpression(node)
@@ -6237,7 +6237,7 @@ export class JSXExpressionContainerMatcher extends Matcher<t.JSXExpressionContai
     super();
   }
 
-  match(node: unknown): node is t.JSXExpressionContainer {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXExpressionContainer {
     if (
       !isNode(node) ||
       !t.isJSXExpressionContainer(node)
@@ -6247,7 +6247,7 @@ export class JSXExpressionContainerMatcher extends Matcher<t.JSXExpressionContai
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -6270,7 +6270,7 @@ export class JSXSpreadChildMatcher extends Matcher<t.JSXSpreadChild> {
     super();
   }
 
-  match(node: unknown): node is t.JSXSpreadChild {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXSpreadChild {
     if (
       !isNode(node) ||
       !t.isJSXSpreadChild(node)
@@ -6280,7 +6280,7 @@ export class JSXSpreadChildMatcher extends Matcher<t.JSXSpreadChild> {
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -6303,7 +6303,7 @@ export class JSXIdentifierMatcher extends Matcher<t.JSXIdentifier> {
     super();
   }
 
-  match(node: unknown): node is t.JSXIdentifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXIdentifier {
     if (
       !isNode(node) ||
       !t.isJSXIdentifier(node)
@@ -6317,7 +6317,7 @@ export class JSXIdentifierMatcher extends Matcher<t.JSXIdentifier> {
       if (this.name !== node.name) {
         return false;
       }
-    } else if (!this.name.match(node.name)) {
+    } else if (!this.name.matchValue(node.name, [...keys, 'name'])) {
       return false;
     }
 
@@ -6341,7 +6341,7 @@ export class JSXMemberExpressionMatcher extends Matcher<t.JSXMemberExpression> {
     super();
   }
 
-  match(node: unknown): node is t.JSXMemberExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXMemberExpression {
     if (
       !isNode(node) ||
       !t.isJSXMemberExpression(node)
@@ -6351,13 +6351,13 @@ export class JSXMemberExpressionMatcher extends Matcher<t.JSXMemberExpression> {
 
     if (typeof this.object === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.object.match(node.object)) {
+    } else if (!this.object.matchValue(node.object, [...keys, 'object'])) {
       return false;
     }
 
     if (typeof this.property === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.property.match(node.property)) {
+    } else if (!this.property.matchValue(node.property, [...keys, 'property'])) {
       return false;
     }
 
@@ -6383,7 +6383,7 @@ export class JSXNamespacedNameMatcher extends Matcher<t.JSXNamespacedName> {
     super();
   }
 
-  match(node: unknown): node is t.JSXNamespacedName {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXNamespacedName {
     if (
       !isNode(node) ||
       !t.isJSXNamespacedName(node)
@@ -6393,13 +6393,13 @@ export class JSXNamespacedNameMatcher extends Matcher<t.JSXNamespacedName> {
 
     if (typeof this.namespace === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.namespace.match(node.namespace)) {
+    } else if (!this.namespace.matchValue(node.namespace, [...keys, 'namespace'])) {
       return false;
     }
 
     if (typeof this.name === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.name.match(node.name)) {
+    } else if (!this.name.matchValue(node.name, [...keys, 'name'])) {
       return false;
     }
 
@@ -6426,7 +6426,7 @@ export class JSXOpeningElementMatcher extends Matcher<t.JSXOpeningElement> {
     super();
   }
 
-  match(node: unknown): node is t.JSXOpeningElement {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXOpeningElement {
     if (
       !isNode(node) ||
       !t.isJSXOpeningElement(node)
@@ -6436,17 +6436,17 @@ export class JSXOpeningElementMatcher extends Matcher<t.JSXOpeningElement> {
 
     if (typeof this.name === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.name.match(node.name)) {
+    } else if (!this.name.matchValue(node.name, [...keys, 'name'])) {
       return false;
     }
 
     if (typeof this.attributes === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.attributes)) {
-      if (!tupleOf<unknown>(...this.attributes).match(node.attributes)) {
+      if (!tupleOf<unknown>(...this.attributes).matchValue(node.attributes, [...keys, 'attributes'])) {
         return false;
       }
-    } else if (!this.attributes.match(node.attributes)) {
+    } else if (!this.attributes.matchValue(node.attributes, [...keys, 'attributes'])) {
       return false;
     }
 
@@ -6456,7 +6456,7 @@ export class JSXOpeningElementMatcher extends Matcher<t.JSXOpeningElement> {
       if (this.selfClosing !== node.selfClosing) {
         return false;
       }
-    } else if (!this.selfClosing.match(node.selfClosing)) {
+    } else if (!this.selfClosing.matchValue(node.selfClosing, [...keys, 'selfClosing'])) {
       return false;
     }
 
@@ -6483,7 +6483,7 @@ export class JSXSpreadAttributeMatcher extends Matcher<t.JSXSpreadAttribute> {
     super();
   }
 
-  match(node: unknown): node is t.JSXSpreadAttribute {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXSpreadAttribute {
     if (
       !isNode(node) ||
       !t.isJSXSpreadAttribute(node)
@@ -6493,7 +6493,7 @@ export class JSXSpreadAttributeMatcher extends Matcher<t.JSXSpreadAttribute> {
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -6516,7 +6516,7 @@ export class JSXTextMatcher extends Matcher<t.JSXText> {
     super();
   }
 
-  match(node: unknown): node is t.JSXText {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXText {
     if (
       !isNode(node) ||
       !t.isJSXText(node)
@@ -6530,7 +6530,7 @@ export class JSXTextMatcher extends Matcher<t.JSXText> {
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -6555,7 +6555,7 @@ export class JSXFragmentMatcher extends Matcher<t.JSXFragment> {
     super();
   }
 
-  match(node: unknown): node is t.JSXFragment {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXFragment {
     if (
       !isNode(node) ||
       !t.isJSXFragment(node)
@@ -6565,23 +6565,23 @@ export class JSXFragmentMatcher extends Matcher<t.JSXFragment> {
 
     if (typeof this.openingFragment === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.openingFragment.match(node.openingFragment)) {
+    } else if (!this.openingFragment.matchValue(node.openingFragment, [...keys, 'openingFragment'])) {
       return false;
     }
 
     if (typeof this.closingFragment === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.closingFragment.match(node.closingFragment)) {
+    } else if (!this.closingFragment.matchValue(node.closingFragment, [...keys, 'closingFragment'])) {
       return false;
     }
 
     if (typeof this.children === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.children)) {
-      if (!tupleOf<unknown>(...this.children).match(node.children)) {
+      if (!tupleOf<unknown>(...this.children).matchValue(node.children, [...keys, 'children'])) {
         return false;
       }
-    } else if (!this.children.match(node.children)) {
+    } else if (!this.children.matchValue(node.children, [...keys, 'children'])) {
       return false;
     }
 
@@ -6607,7 +6607,7 @@ export class JSXOpeningFragmentMatcher extends Matcher<t.JSXOpeningFragment> {
     super();
   }
 
-  match(node: unknown): node is t.JSXOpeningFragment {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXOpeningFragment {
     if (
       !isNode(node) ||
       !t.isJSXOpeningFragment(node)
@@ -6631,7 +6631,7 @@ export class JSXClosingFragmentMatcher extends Matcher<t.JSXClosingFragment> {
     super();
   }
 
-  match(node: unknown): node is t.JSXClosingFragment {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.JSXClosingFragment {
     if (
       !isNode(node) ||
       !t.isJSXClosingFragment(node)
@@ -6655,7 +6655,7 @@ export class NoopMatcher extends Matcher<t.Noop> {
     super();
   }
 
-  match(node: unknown): node is t.Noop {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.Noop {
     if (
       !isNode(node) ||
       !t.isNoop(node)
@@ -6680,7 +6680,7 @@ export class ParenthesizedExpressionMatcher extends Matcher<t.ParenthesizedExpre
     super();
   }
 
-  match(node: unknown): node is t.ParenthesizedExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ParenthesizedExpression {
     if (
       !isNode(node) ||
       !t.isParenthesizedExpression(node)
@@ -6690,7 +6690,7 @@ export class ParenthesizedExpressionMatcher extends Matcher<t.ParenthesizedExpre
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -6713,7 +6713,7 @@ export class AwaitExpressionMatcher extends Matcher<t.AwaitExpression> {
     super();
   }
 
-  match(node: unknown): node is t.AwaitExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.AwaitExpression {
     if (
       !isNode(node) ||
       !t.isAwaitExpression(node)
@@ -6723,7 +6723,7 @@ export class AwaitExpressionMatcher extends Matcher<t.AwaitExpression> {
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -6747,7 +6747,7 @@ export class BindExpressionMatcher extends Matcher<t.BindExpression> {
     super();
   }
 
-  match(node: unknown): node is t.BindExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.BindExpression {
     if (
       !isNode(node) ||
       !t.isBindExpression(node)
@@ -6757,13 +6757,13 @@ export class BindExpressionMatcher extends Matcher<t.BindExpression> {
 
     if (typeof this.object === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.object.match(node.object)) {
+    } else if (!this.object.matchValue(node.object, [...keys, 'object'])) {
       return false;
     }
 
     if (typeof this.callee === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.callee.match(node.callee)) {
+    } else if (!this.callee.matchValue(node.callee, [...keys, 'callee'])) {
       return false;
     }
 
@@ -6792,7 +6792,7 @@ export class ClassPropertyMatcher extends Matcher<t.ClassProperty> {
     super();
   }
 
-  match(node: unknown): node is t.ClassProperty {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ClassProperty {
     if (
       !isNode(node) ||
       !t.isClassProperty(node)
@@ -6802,7 +6802,7 @@ export class ClassPropertyMatcher extends Matcher<t.ClassProperty> {
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
@@ -6815,7 +6815,7 @@ export class ClassPropertyMatcher extends Matcher<t.ClassProperty> {
       }
     } else if (node.value === null) {
       return false;
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -6828,7 +6828,7 @@ export class ClassPropertyMatcher extends Matcher<t.ClassProperty> {
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -6842,10 +6842,10 @@ export class ClassPropertyMatcher extends Matcher<t.ClassProperty> {
     } else if (node.decorators === null) {
       return false;
     } else if (Array.isArray(this.decorators)) {
-      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).matchValue(node.decorators, [...keys, 'decorators'])) {
         return false;
       }
-    } else if (!this.decorators.match(node.decorators)) {
+    } else if (!this.decorators.matchValue(node.decorators, [...keys, 'decorators'])) {
       return false;
     }
 
@@ -6862,7 +6862,7 @@ export class ClassPropertyMatcher extends Matcher<t.ClassProperty> {
       }
     } else if (node.computed === null) {
       return false;
-    } else if (!this.computed.match(node.computed)) {
+    } else if (!this.computed.matchValue(node.computed, [...keys, 'computed'])) {
       return false;
     }
 
@@ -6896,7 +6896,7 @@ export class OptionalMemberExpressionMatcher extends Matcher<t.OptionalMemberExp
     super();
   }
 
-  match(node: unknown): node is t.OptionalMemberExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.OptionalMemberExpression {
     if (
       !isNode(node) ||
       !t.isOptionalMemberExpression(node)
@@ -6906,13 +6906,13 @@ export class OptionalMemberExpressionMatcher extends Matcher<t.OptionalMemberExp
 
     if (typeof this.object === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.object.match(node.object)) {
+    } else if (!this.object.matchValue(node.object, [...keys, 'object'])) {
       return false;
     }
 
     if (typeof this.property === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.property.match(node.property)) {
+    } else if (!this.property.matchValue(node.property, [...keys, 'property'])) {
       return false;
     }
 
@@ -6922,7 +6922,7 @@ export class OptionalMemberExpressionMatcher extends Matcher<t.OptionalMemberExp
       if (this.computed !== node.computed) {
         return false;
       }
-    } else if (!this.computed.match(node.computed)) {
+    } else if (!this.computed.matchValue(node.computed, [...keys, 'computed'])) {
       return false;
     }
 
@@ -6932,7 +6932,7 @@ export class OptionalMemberExpressionMatcher extends Matcher<t.OptionalMemberExp
       if (this.optional !== node.optional) {
         return false;
       }
-    } else if (!this.optional.match(node.optional)) {
+    } else if (!this.optional.matchValue(node.optional, [...keys, 'optional'])) {
       return false;
     }
 
@@ -6961,7 +6961,7 @@ export class PipelineTopicExpressionMatcher extends Matcher<t.PipelineTopicExpre
     super();
   }
 
-  match(node: unknown): node is t.PipelineTopicExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.PipelineTopicExpression {
     if (
       !isNode(node) ||
       !t.isPipelineTopicExpression(node)
@@ -6971,7 +6971,7 @@ export class PipelineTopicExpressionMatcher extends Matcher<t.PipelineTopicExpre
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -6994,7 +6994,7 @@ export class PipelineBareFunctionMatcher extends Matcher<t.PipelineBareFunction>
     super();
   }
 
-  match(node: unknown): node is t.PipelineBareFunction {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.PipelineBareFunction {
     if (
       !isNode(node) ||
       !t.isPipelineBareFunction(node)
@@ -7004,7 +7004,7 @@ export class PipelineBareFunctionMatcher extends Matcher<t.PipelineBareFunction>
 
     if (typeof this.callee === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.callee.match(node.callee)) {
+    } else if (!this.callee.matchValue(node.callee, [...keys, 'callee'])) {
       return false;
     }
 
@@ -7026,7 +7026,7 @@ export class PipelinePrimaryTopicReferenceMatcher extends Matcher<t.PipelinePrim
     super();
   }
 
-  match(node: unknown): node is t.PipelinePrimaryTopicReference {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.PipelinePrimaryTopicReference {
     if (
       !isNode(node) ||
       !t.isPipelinePrimaryTopicReference(node)
@@ -7053,7 +7053,7 @@ export class OptionalCallExpressionMatcher extends Matcher<t.OptionalCallExpress
     super();
   }
 
-  match(node: unknown): node is t.OptionalCallExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.OptionalCallExpression {
     if (
       !isNode(node) ||
       !t.isOptionalCallExpression(node)
@@ -7063,17 +7063,17 @@ export class OptionalCallExpressionMatcher extends Matcher<t.OptionalCallExpress
 
     if (typeof this.callee === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.callee.match(node.callee)) {
+    } else if (!this.callee.matchValue(node.callee, [...keys, 'callee'])) {
       return false;
     }
 
     if (typeof this._arguments === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this._arguments)) {
-      if (!tupleOf<unknown>(...this._arguments).match(node.arguments)) {
+      if (!tupleOf<unknown>(...this._arguments).matchValue(node.arguments, [...keys, 'arguments'])) {
         return false;
       }
-    } else if (!this._arguments.match(node.arguments)) {
+    } else if (!this._arguments.matchValue(node.arguments, [...keys, 'arguments'])) {
       return false;
     }
 
@@ -7083,7 +7083,7 @@ export class OptionalCallExpressionMatcher extends Matcher<t.OptionalCallExpress
       if (this.optional !== node.optional) {
         return false;
       }
-    } else if (!this.optional.match(node.optional)) {
+    } else if (!this.optional.matchValue(node.optional, [...keys, 'optional'])) {
       return false;
     }
 
@@ -7111,7 +7111,7 @@ export class ClassPrivatePropertyMatcher extends Matcher<t.ClassPrivateProperty>
     super();
   }
 
-  match(node: unknown): node is t.ClassPrivateProperty {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ClassPrivateProperty {
     if (
       !isNode(node) ||
       !t.isClassPrivateProperty(node)
@@ -7121,7 +7121,7 @@ export class ClassPrivatePropertyMatcher extends Matcher<t.ClassPrivateProperty>
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
@@ -7134,7 +7134,7 @@ export class ClassPrivatePropertyMatcher extends Matcher<t.ClassPrivateProperty>
       }
     } else if (node.value === null) {
       return false;
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -7163,7 +7163,7 @@ export class ClassPrivateMethodMatcher extends Matcher<t.ClassPrivateMethod> {
     super();
   }
 
-  match(node: unknown): node is t.ClassPrivateMethod {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ClassPrivateMethod {
     if (
       !isNode(node) ||
       !t.isClassPrivateMethod(node)
@@ -7184,29 +7184,29 @@ export class ClassPrivateMethodMatcher extends Matcher<t.ClassPrivateMethod> {
       }
     } else if (node.kind === null) {
       return false;
-    } else if (!this.kind.match(node.kind)) {
+    } else if (!this.kind.matchValue(node.kind, [...keys, 'kind'])) {
       return false;
     }
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -7223,7 +7223,7 @@ export class ClassPrivateMethodMatcher extends Matcher<t.ClassPrivateMethod> {
       }
     } else if (node.static === null) {
       return false;
-    } else if (!this._static.match(node.static)) {
+    } else if (!this._static.matchValue(node.static, [...keys, 'static'])) {
       return false;
     }
 
@@ -7253,7 +7253,7 @@ export class ImportMatcher extends Matcher<t.Import> {
     super();
   }
 
-  match(node: unknown): node is t.Import {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.Import {
     if (
       !isNode(node) ||
       !t.isImport(node)
@@ -7278,7 +7278,7 @@ export class DecoratorMatcher extends Matcher<t.Decorator> {
     super();
   }
 
-  match(node: unknown): node is t.Decorator {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.Decorator {
     if (
       !isNode(node) ||
       !t.isDecorator(node)
@@ -7288,7 +7288,7 @@ export class DecoratorMatcher extends Matcher<t.Decorator> {
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -7311,7 +7311,7 @@ export class DoExpressionMatcher extends Matcher<t.DoExpression> {
     super();
   }
 
-  match(node: unknown): node is t.DoExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.DoExpression {
     if (
       !isNode(node) ||
       !t.isDoExpression(node)
@@ -7321,7 +7321,7 @@ export class DoExpressionMatcher extends Matcher<t.DoExpression> {
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -7344,7 +7344,7 @@ export class ExportDefaultSpecifierMatcher extends Matcher<t.ExportDefaultSpecif
     super();
   }
 
-  match(node: unknown): node is t.ExportDefaultSpecifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ExportDefaultSpecifier {
     if (
       !isNode(node) ||
       !t.isExportDefaultSpecifier(node)
@@ -7354,7 +7354,7 @@ export class ExportDefaultSpecifierMatcher extends Matcher<t.ExportDefaultSpecif
 
     if (typeof this.exported === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.exported.match(node.exported)) {
+    } else if (!this.exported.matchValue(node.exported, [...keys, 'exported'])) {
       return false;
     }
 
@@ -7377,7 +7377,7 @@ export class ExportNamespaceSpecifierMatcher extends Matcher<t.ExportNamespaceSp
     super();
   }
 
-  match(node: unknown): node is t.ExportNamespaceSpecifier {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.ExportNamespaceSpecifier {
     if (
       !isNode(node) ||
       !t.isExportNamespaceSpecifier(node)
@@ -7387,7 +7387,7 @@ export class ExportNamespaceSpecifierMatcher extends Matcher<t.ExportNamespaceSp
 
     if (typeof this.exported === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.exported.match(node.exported)) {
+    } else if (!this.exported.matchValue(node.exported, [...keys, 'exported'])) {
       return false;
     }
 
@@ -7410,7 +7410,7 @@ export class PrivateNameMatcher extends Matcher<t.PrivateName> {
     super();
   }
 
-  match(node: unknown): node is t.PrivateName {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.PrivateName {
     if (
       !isNode(node) ||
       !t.isPrivateName(node)
@@ -7420,7 +7420,7 @@ export class PrivateNameMatcher extends Matcher<t.PrivateName> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -7443,7 +7443,7 @@ export class BigIntLiteralMatcher extends Matcher<t.BigIntLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.BigIntLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.BigIntLiteral {
     if (
       !isNode(node) ||
       !t.isBigIntLiteral(node)
@@ -7457,7 +7457,7 @@ export class BigIntLiteralMatcher extends Matcher<t.BigIntLiteral> {
       if (this.value !== node.value) {
         return false;
       }
-    } else if (!this.value.match(node.value)) {
+    } else if (!this.value.matchValue(node.value, [...keys, 'value'])) {
       return false;
     }
 
@@ -7480,7 +7480,7 @@ export class TSParameterPropertyMatcher extends Matcher<t.TSParameterProperty> {
     super();
   }
 
-  match(node: unknown): node is t.TSParameterProperty {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSParameterProperty {
     if (
       !isNode(node) ||
       !t.isTSParameterProperty(node)
@@ -7490,7 +7490,7 @@ export class TSParameterPropertyMatcher extends Matcher<t.TSParameterProperty> {
 
     if (typeof this.parameter === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.parameter.match(node.parameter)) {
+    } else if (!this.parameter.matchValue(node.parameter, [...keys, 'parameter'])) {
       return false;
     }
 
@@ -7516,7 +7516,7 @@ export class TSDeclareFunctionMatcher extends Matcher<t.TSDeclareFunction> {
     super();
   }
 
-  match(node: unknown): node is t.TSDeclareFunction {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSDeclareFunction {
     if (
       !isNode(node) ||
       !t.isTSDeclareFunction(node)
@@ -7533,7 +7533,7 @@ export class TSDeclareFunctionMatcher extends Matcher<t.TSDeclareFunction> {
       }
     } else if (node.id === null) {
       return false;
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -7546,17 +7546,17 @@ export class TSDeclareFunctionMatcher extends Matcher<t.TSDeclareFunction> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
@@ -7569,7 +7569,7 @@ export class TSDeclareFunctionMatcher extends Matcher<t.TSDeclareFunction> {
       }
     } else if (node.returnType === null) {
       return false;
-    } else if (!this.returnType.match(node.returnType)) {
+    } else if (!this.returnType.matchValue(node.returnType, [...keys, 'returnType'])) {
       return false;
     }
 
@@ -7602,7 +7602,7 @@ export class TSDeclareMethodMatcher extends Matcher<t.TSDeclareMethod> {
     super();
   }
 
-  match(node: unknown): node is t.TSDeclareMethod {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSDeclareMethod {
     if (
       !isNode(node) ||
       !t.isTSDeclareMethod(node)
@@ -7620,16 +7620,16 @@ export class TSDeclareMethodMatcher extends Matcher<t.TSDeclareMethod> {
     } else if (node.decorators === null) {
       return false;
     } else if (Array.isArray(this.decorators)) {
-      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).matchValue(node.decorators, [...keys, 'decorators'])) {
         return false;
       }
-    } else if (!this.decorators.match(node.decorators)) {
+    } else if (!this.decorators.matchValue(node.decorators, [...keys, 'decorators'])) {
       return false;
     }
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
@@ -7642,17 +7642,17 @@ export class TSDeclareMethodMatcher extends Matcher<t.TSDeclareMethod> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
@@ -7665,7 +7665,7 @@ export class TSDeclareMethodMatcher extends Matcher<t.TSDeclareMethod> {
       }
     } else if (node.returnType === null) {
       return false;
-    } else if (!this.returnType.match(node.returnType)) {
+    } else if (!this.returnType.matchValue(node.returnType, [...keys, 'returnType'])) {
       return false;
     }
 
@@ -7697,7 +7697,7 @@ export class TSQualifiedNameMatcher extends Matcher<t.TSQualifiedName> {
     super();
   }
 
-  match(node: unknown): node is t.TSQualifiedName {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSQualifiedName {
     if (
       !isNode(node) ||
       !t.isTSQualifiedName(node)
@@ -7707,13 +7707,13 @@ export class TSQualifiedNameMatcher extends Matcher<t.TSQualifiedName> {
 
     if (typeof this.left === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.left.match(node.left)) {
+    } else if (!this.left.matchValue(node.left, [...keys, 'left'])) {
       return false;
     }
 
     if (typeof this.right === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.right.match(node.right)) {
+    } else if (!this.right.matchValue(node.right, [...keys, 'right'])) {
       return false;
     }
 
@@ -7740,7 +7740,7 @@ export class TSCallSignatureDeclarationMatcher extends Matcher<t.TSCallSignature
     super();
   }
 
-  match(node: unknown): node is t.TSCallSignatureDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSCallSignatureDeclaration {
     if (
       !isNode(node) ||
       !t.isTSCallSignatureDeclaration(node)
@@ -7757,7 +7757,7 @@ export class TSCallSignatureDeclarationMatcher extends Matcher<t.TSCallSignature
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -7771,10 +7771,10 @@ export class TSCallSignatureDeclarationMatcher extends Matcher<t.TSCallSignature
     } else if (node.parameters === null) {
       return false;
     } else if (Array.isArray(this.parameters)) {
-      if (!tupleOf<unknown>(...this.parameters).match(node.parameters)) {
+      if (!tupleOf<unknown>(...this.parameters).matchValue(node.parameters, [...keys, 'parameters'])) {
         return false;
       }
-    } else if (!this.parameters.match(node.parameters)) {
+    } else if (!this.parameters.matchValue(node.parameters, [...keys, 'parameters'])) {
       return false;
     }
 
@@ -7787,7 +7787,7 @@ export class TSCallSignatureDeclarationMatcher extends Matcher<t.TSCallSignature
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -7816,7 +7816,7 @@ export class TSConstructSignatureDeclarationMatcher extends Matcher<t.TSConstruc
     super();
   }
 
-  match(node: unknown): node is t.TSConstructSignatureDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSConstructSignatureDeclaration {
     if (
       !isNode(node) ||
       !t.isTSConstructSignatureDeclaration(node)
@@ -7833,7 +7833,7 @@ export class TSConstructSignatureDeclarationMatcher extends Matcher<t.TSConstruc
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -7847,10 +7847,10 @@ export class TSConstructSignatureDeclarationMatcher extends Matcher<t.TSConstruc
     } else if (node.parameters === null) {
       return false;
     } else if (Array.isArray(this.parameters)) {
-      if (!tupleOf<unknown>(...this.parameters).match(node.parameters)) {
+      if (!tupleOf<unknown>(...this.parameters).matchValue(node.parameters, [...keys, 'parameters'])) {
         return false;
       }
-    } else if (!this.parameters.match(node.parameters)) {
+    } else if (!this.parameters.matchValue(node.parameters, [...keys, 'parameters'])) {
       return false;
     }
 
@@ -7863,7 +7863,7 @@ export class TSConstructSignatureDeclarationMatcher extends Matcher<t.TSConstruc
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -7892,7 +7892,7 @@ export class TSPropertySignatureMatcher extends Matcher<t.TSPropertySignature> {
     super();
   }
 
-  match(node: unknown): node is t.TSPropertySignature {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSPropertySignature {
     if (
       !isNode(node) ||
       !t.isTSPropertySignature(node)
@@ -7902,7 +7902,7 @@ export class TSPropertySignatureMatcher extends Matcher<t.TSPropertySignature> {
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
@@ -7915,7 +7915,7 @@ export class TSPropertySignatureMatcher extends Matcher<t.TSPropertySignature> {
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -7928,7 +7928,7 @@ export class TSPropertySignatureMatcher extends Matcher<t.TSPropertySignature> {
       }
     } else if (node.initializer === null) {
       return false;
-    } else if (!this.initializer.match(node.initializer)) {
+    } else if (!this.initializer.matchValue(node.initializer, [...keys, 'initializer'])) {
       return false;
     }
 
@@ -7958,7 +7958,7 @@ export class TSMethodSignatureMatcher extends Matcher<t.TSMethodSignature> {
     super();
   }
 
-  match(node: unknown): node is t.TSMethodSignature {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSMethodSignature {
     if (
       !isNode(node) ||
       !t.isTSMethodSignature(node)
@@ -7968,7 +7968,7 @@ export class TSMethodSignatureMatcher extends Matcher<t.TSMethodSignature> {
 
     if (typeof this.key === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.key.match(node.key)) {
+    } else if (!this.key.matchValue(node.key, [...keys, 'key'])) {
       return false;
     }
 
@@ -7981,7 +7981,7 @@ export class TSMethodSignatureMatcher extends Matcher<t.TSMethodSignature> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -7995,10 +7995,10 @@ export class TSMethodSignatureMatcher extends Matcher<t.TSMethodSignature> {
     } else if (node.parameters === null) {
       return false;
     } else if (Array.isArray(this.parameters)) {
-      if (!tupleOf<unknown>(...this.parameters).match(node.parameters)) {
+      if (!tupleOf<unknown>(...this.parameters).matchValue(node.parameters, [...keys, 'parameters'])) {
         return false;
       }
-    } else if (!this.parameters.match(node.parameters)) {
+    } else if (!this.parameters.matchValue(node.parameters, [...keys, 'parameters'])) {
       return false;
     }
 
@@ -8011,7 +8011,7 @@ export class TSMethodSignatureMatcher extends Matcher<t.TSMethodSignature> {
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -8041,7 +8041,7 @@ export class TSIndexSignatureMatcher extends Matcher<t.TSIndexSignature> {
     super();
   }
 
-  match(node: unknown): node is t.TSIndexSignature {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSIndexSignature {
     if (
       !isNode(node) ||
       !t.isTSIndexSignature(node)
@@ -8052,10 +8052,10 @@ export class TSIndexSignatureMatcher extends Matcher<t.TSIndexSignature> {
     if (typeof this.parameters === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.parameters)) {
-      if (!tupleOf<unknown>(...this.parameters).match(node.parameters)) {
+      if (!tupleOf<unknown>(...this.parameters).matchValue(node.parameters, [...keys, 'parameters'])) {
         return false;
       }
-    } else if (!this.parameters.match(node.parameters)) {
+    } else if (!this.parameters.matchValue(node.parameters, [...keys, 'parameters'])) {
       return false;
     }
 
@@ -8068,7 +8068,7 @@ export class TSIndexSignatureMatcher extends Matcher<t.TSIndexSignature> {
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -8092,7 +8092,7 @@ export class TSAnyKeywordMatcher extends Matcher<t.TSAnyKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSAnyKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSAnyKeyword {
     if (
       !isNode(node) ||
       !t.isTSAnyKeyword(node)
@@ -8116,7 +8116,7 @@ export class TSUnknownKeywordMatcher extends Matcher<t.TSUnknownKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSUnknownKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSUnknownKeyword {
     if (
       !isNode(node) ||
       !t.isTSUnknownKeyword(node)
@@ -8140,7 +8140,7 @@ export class TSNumberKeywordMatcher extends Matcher<t.TSNumberKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSNumberKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSNumberKeyword {
     if (
       !isNode(node) ||
       !t.isTSNumberKeyword(node)
@@ -8164,7 +8164,7 @@ export class TSObjectKeywordMatcher extends Matcher<t.TSObjectKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSObjectKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSObjectKeyword {
     if (
       !isNode(node) ||
       !t.isTSObjectKeyword(node)
@@ -8188,7 +8188,7 @@ export class TSBooleanKeywordMatcher extends Matcher<t.TSBooleanKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSBooleanKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSBooleanKeyword {
     if (
       !isNode(node) ||
       !t.isTSBooleanKeyword(node)
@@ -8212,7 +8212,7 @@ export class TSStringKeywordMatcher extends Matcher<t.TSStringKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSStringKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSStringKeyword {
     if (
       !isNode(node) ||
       !t.isTSStringKeyword(node)
@@ -8236,7 +8236,7 @@ export class TSSymbolKeywordMatcher extends Matcher<t.TSSymbolKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSSymbolKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSSymbolKeyword {
     if (
       !isNode(node) ||
       !t.isTSSymbolKeyword(node)
@@ -8260,7 +8260,7 @@ export class TSVoidKeywordMatcher extends Matcher<t.TSVoidKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSVoidKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSVoidKeyword {
     if (
       !isNode(node) ||
       !t.isTSVoidKeyword(node)
@@ -8284,7 +8284,7 @@ export class TSUndefinedKeywordMatcher extends Matcher<t.TSUndefinedKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSUndefinedKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSUndefinedKeyword {
     if (
       !isNode(node) ||
       !t.isTSUndefinedKeyword(node)
@@ -8308,7 +8308,7 @@ export class TSNullKeywordMatcher extends Matcher<t.TSNullKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSNullKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSNullKeyword {
     if (
       !isNode(node) ||
       !t.isTSNullKeyword(node)
@@ -8332,7 +8332,7 @@ export class TSNeverKeywordMatcher extends Matcher<t.TSNeverKeyword> {
     super();
   }
 
-  match(node: unknown): node is t.TSNeverKeyword {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSNeverKeyword {
     if (
       !isNode(node) ||
       !t.isTSNeverKeyword(node)
@@ -8356,7 +8356,7 @@ export class TSThisTypeMatcher extends Matcher<t.TSThisType> {
     super();
   }
 
-  match(node: unknown): node is t.TSThisType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSThisType {
     if (
       !isNode(node) ||
       !t.isTSThisType(node)
@@ -8382,7 +8382,7 @@ export class TSFunctionTypeMatcher extends Matcher<t.TSFunctionType> {
     super();
   }
 
-  match(node: unknown): node is t.TSFunctionType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSFunctionType {
     if (
       !isNode(node) ||
       !t.isTSFunctionType(node)
@@ -8399,7 +8399,7 @@ export class TSFunctionTypeMatcher extends Matcher<t.TSFunctionType> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -8412,7 +8412,7 @@ export class TSFunctionTypeMatcher extends Matcher<t.TSFunctionType> {
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -8438,7 +8438,7 @@ export class TSConstructorTypeMatcher extends Matcher<t.TSConstructorType> {
     super();
   }
 
-  match(node: unknown): node is t.TSConstructorType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSConstructorType {
     if (
       !isNode(node) ||
       !t.isTSConstructorType(node)
@@ -8455,7 +8455,7 @@ export class TSConstructorTypeMatcher extends Matcher<t.TSConstructorType> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -8468,7 +8468,7 @@ export class TSConstructorTypeMatcher extends Matcher<t.TSConstructorType> {
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -8494,7 +8494,7 @@ export class TSTypeReferenceMatcher extends Matcher<t.TSTypeReference> {
     super();
   }
 
-  match(node: unknown): node is t.TSTypeReference {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeReference {
     if (
       !isNode(node) ||
       !t.isTSTypeReference(node)
@@ -8504,7 +8504,7 @@ export class TSTypeReferenceMatcher extends Matcher<t.TSTypeReference> {
 
     if (typeof this.typeName === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeName.match(node.typeName)) {
+    } else if (!this.typeName.matchValue(node.typeName, [...keys, 'typeName'])) {
       return false;
     }
 
@@ -8517,7 +8517,7 @@ export class TSTypeReferenceMatcher extends Matcher<t.TSTypeReference> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -8543,7 +8543,7 @@ export class TSTypePredicateMatcher extends Matcher<t.TSTypePredicate> {
     super();
   }
 
-  match(node: unknown): node is t.TSTypePredicate {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypePredicate {
     if (
       !isNode(node) ||
       !t.isTSTypePredicate(node)
@@ -8553,13 +8553,13 @@ export class TSTypePredicateMatcher extends Matcher<t.TSTypePredicate> {
 
     if (typeof this.parameterName === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.parameterName.match(node.parameterName)) {
+    } else if (!this.parameterName.matchValue(node.parameterName, [...keys, 'parameterName'])) {
       return false;
     }
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -8584,7 +8584,7 @@ export class TSTypeQueryMatcher extends Matcher<t.TSTypeQuery> {
     super();
   }
 
-  match(node: unknown): node is t.TSTypeQuery {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeQuery {
     if (
       !isNode(node) ||
       !t.isTSTypeQuery(node)
@@ -8594,7 +8594,7 @@ export class TSTypeQueryMatcher extends Matcher<t.TSTypeQuery> {
 
     if (typeof this.exprName === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.exprName.match(node.exprName)) {
+    } else if (!this.exprName.matchValue(node.exprName, [...keys, 'exprName'])) {
       return false;
     }
 
@@ -8617,7 +8617,7 @@ export class TSTypeLiteralMatcher extends Matcher<t.TSTypeLiteral> {
     super();
   }
 
-  match(node: unknown): node is t.TSTypeLiteral {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeLiteral {
     if (
       !isNode(node) ||
       !t.isTSTypeLiteral(node)
@@ -8628,10 +8628,10 @@ export class TSTypeLiteralMatcher extends Matcher<t.TSTypeLiteral> {
     if (typeof this.members === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.members)) {
-      if (!tupleOf<unknown>(...this.members).match(node.members)) {
+      if (!tupleOf<unknown>(...this.members).matchValue(node.members, [...keys, 'members'])) {
         return false;
       }
-    } else if (!this.members.match(node.members)) {
+    } else if (!this.members.matchValue(node.members, [...keys, 'members'])) {
       return false;
     }
 
@@ -8654,7 +8654,7 @@ export class TSArrayTypeMatcher extends Matcher<t.TSArrayType> {
     super();
   }
 
-  match(node: unknown): node is t.TSArrayType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSArrayType {
     if (
       !isNode(node) ||
       !t.isTSArrayType(node)
@@ -8664,7 +8664,7 @@ export class TSArrayTypeMatcher extends Matcher<t.TSArrayType> {
 
     if (typeof this.elementType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.elementType.match(node.elementType)) {
+    } else if (!this.elementType.matchValue(node.elementType, [...keys, 'elementType'])) {
       return false;
     }
 
@@ -8687,7 +8687,7 @@ export class TSTupleTypeMatcher extends Matcher<t.TSTupleType> {
     super();
   }
 
-  match(node: unknown): node is t.TSTupleType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTupleType {
     if (
       !isNode(node) ||
       !t.isTSTupleType(node)
@@ -8698,10 +8698,10 @@ export class TSTupleTypeMatcher extends Matcher<t.TSTupleType> {
     if (typeof this.elementTypes === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.elementTypes)) {
-      if (!tupleOf<unknown>(...this.elementTypes).match(node.elementTypes)) {
+      if (!tupleOf<unknown>(...this.elementTypes).matchValue(node.elementTypes, [...keys, 'elementTypes'])) {
         return false;
       }
-    } else if (!this.elementTypes.match(node.elementTypes)) {
+    } else if (!this.elementTypes.matchValue(node.elementTypes, [...keys, 'elementTypes'])) {
       return false;
     }
 
@@ -8724,7 +8724,7 @@ export class TSOptionalTypeMatcher extends Matcher<t.TSOptionalType> {
     super();
   }
 
-  match(node: unknown): node is t.TSOptionalType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSOptionalType {
     if (
       !isNode(node) ||
       !t.isTSOptionalType(node)
@@ -8734,7 +8734,7 @@ export class TSOptionalTypeMatcher extends Matcher<t.TSOptionalType> {
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -8757,7 +8757,7 @@ export class TSRestTypeMatcher extends Matcher<t.TSRestType> {
     super();
   }
 
-  match(node: unknown): node is t.TSRestType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSRestType {
     if (
       !isNode(node) ||
       !t.isTSRestType(node)
@@ -8767,7 +8767,7 @@ export class TSRestTypeMatcher extends Matcher<t.TSRestType> {
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -8790,7 +8790,7 @@ export class TSUnionTypeMatcher extends Matcher<t.TSUnionType> {
     super();
   }
 
-  match(node: unknown): node is t.TSUnionType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSUnionType {
     if (
       !isNode(node) ||
       !t.isTSUnionType(node)
@@ -8801,10 +8801,10 @@ export class TSUnionTypeMatcher extends Matcher<t.TSUnionType> {
     if (typeof this.types === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.types)) {
-      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+      if (!tupleOf<unknown>(...this.types).matchValue(node.types, [...keys, 'types'])) {
         return false;
       }
-    } else if (!this.types.match(node.types)) {
+    } else if (!this.types.matchValue(node.types, [...keys, 'types'])) {
       return false;
     }
 
@@ -8827,7 +8827,7 @@ export class TSIntersectionTypeMatcher extends Matcher<t.TSIntersectionType> {
     super();
   }
 
-  match(node: unknown): node is t.TSIntersectionType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSIntersectionType {
     if (
       !isNode(node) ||
       !t.isTSIntersectionType(node)
@@ -8838,10 +8838,10 @@ export class TSIntersectionTypeMatcher extends Matcher<t.TSIntersectionType> {
     if (typeof this.types === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.types)) {
-      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+      if (!tupleOf<unknown>(...this.types).matchValue(node.types, [...keys, 'types'])) {
         return false;
       }
-    } else if (!this.types.match(node.types)) {
+    } else if (!this.types.matchValue(node.types, [...keys, 'types'])) {
       return false;
     }
 
@@ -8867,7 +8867,7 @@ export class TSConditionalTypeMatcher extends Matcher<t.TSConditionalType> {
     super();
   }
 
-  match(node: unknown): node is t.TSConditionalType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSConditionalType {
     if (
       !isNode(node) ||
       !t.isTSConditionalType(node)
@@ -8877,25 +8877,25 @@ export class TSConditionalTypeMatcher extends Matcher<t.TSConditionalType> {
 
     if (typeof this.checkType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.checkType.match(node.checkType)) {
+    } else if (!this.checkType.matchValue(node.checkType, [...keys, 'checkType'])) {
       return false;
     }
 
     if (typeof this.extendsType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.extendsType.match(node.extendsType)) {
+    } else if (!this.extendsType.matchValue(node.extendsType, [...keys, 'extendsType'])) {
       return false;
     }
 
     if (typeof this.trueType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.trueType.match(node.trueType)) {
+    } else if (!this.trueType.matchValue(node.trueType, [...keys, 'trueType'])) {
       return false;
     }
 
     if (typeof this.falseType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.falseType.match(node.falseType)) {
+    } else if (!this.falseType.matchValue(node.falseType, [...keys, 'falseType'])) {
       return false;
     }
 
@@ -8924,7 +8924,7 @@ export class TSInferTypeMatcher extends Matcher<t.TSInferType> {
     super();
   }
 
-  match(node: unknown): node is t.TSInferType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSInferType {
     if (
       !isNode(node) ||
       !t.isTSInferType(node)
@@ -8934,7 +8934,7 @@ export class TSInferTypeMatcher extends Matcher<t.TSInferType> {
 
     if (typeof this.typeParameter === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeParameter.match(node.typeParameter)) {
+    } else if (!this.typeParameter.matchValue(node.typeParameter, [...keys, 'typeParameter'])) {
       return false;
     }
 
@@ -8957,7 +8957,7 @@ export class TSParenthesizedTypeMatcher extends Matcher<t.TSParenthesizedType> {
     super();
   }
 
-  match(node: unknown): node is t.TSParenthesizedType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSParenthesizedType {
     if (
       !isNode(node) ||
       !t.isTSParenthesizedType(node)
@@ -8967,7 +8967,7 @@ export class TSParenthesizedTypeMatcher extends Matcher<t.TSParenthesizedType> {
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -8990,7 +8990,7 @@ export class TSTypeOperatorMatcher extends Matcher<t.TSTypeOperator> {
     super();
   }
 
-  match(node: unknown): node is t.TSTypeOperator {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeOperator {
     if (
       !isNode(node) ||
       !t.isTSTypeOperator(node)
@@ -9000,7 +9000,7 @@ export class TSTypeOperatorMatcher extends Matcher<t.TSTypeOperator> {
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -9024,7 +9024,7 @@ export class TSIndexedAccessTypeMatcher extends Matcher<t.TSIndexedAccessType> {
     super();
   }
 
-  match(node: unknown): node is t.TSIndexedAccessType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSIndexedAccessType {
     if (
       !isNode(node) ||
       !t.isTSIndexedAccessType(node)
@@ -9034,13 +9034,13 @@ export class TSIndexedAccessTypeMatcher extends Matcher<t.TSIndexedAccessType> {
 
     if (typeof this.objectType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.objectType.match(node.objectType)) {
+    } else if (!this.objectType.matchValue(node.objectType, [...keys, 'objectType'])) {
       return false;
     }
 
     if (typeof this.indexType === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.indexType.match(node.indexType)) {
+    } else if (!this.indexType.matchValue(node.indexType, [...keys, 'indexType'])) {
       return false;
     }
 
@@ -9066,7 +9066,7 @@ export class TSMappedTypeMatcher extends Matcher<t.TSMappedType> {
     super();
   }
 
-  match(node: unknown): node is t.TSMappedType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSMappedType {
     if (
       !isNode(node) ||
       !t.isTSMappedType(node)
@@ -9076,7 +9076,7 @@ export class TSMappedTypeMatcher extends Matcher<t.TSMappedType> {
 
     if (typeof this.typeParameter === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeParameter.match(node.typeParameter)) {
+    } else if (!this.typeParameter.matchValue(node.typeParameter, [...keys, 'typeParameter'])) {
       return false;
     }
 
@@ -9089,7 +9089,7 @@ export class TSMappedTypeMatcher extends Matcher<t.TSMappedType> {
       }
     } else if (node.typeAnnotation === null) {
       return false;
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -9114,7 +9114,7 @@ export class TSLiteralTypeMatcher extends Matcher<t.TSLiteralType> {
     super();
   }
 
-  match(node: unknown): node is t.TSLiteralType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSLiteralType {
     if (
       !isNode(node) ||
       !t.isTSLiteralType(node)
@@ -9124,7 +9124,7 @@ export class TSLiteralTypeMatcher extends Matcher<t.TSLiteralType> {
 
     if (typeof this.literal === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.literal.match(node.literal)) {
+    } else if (!this.literal.matchValue(node.literal, [...keys, 'literal'])) {
       return false;
     }
 
@@ -9148,7 +9148,7 @@ export class TSExpressionWithTypeArgumentsMatcher extends Matcher<t.TSExpression
     super();
   }
 
-  match(node: unknown): node is t.TSExpressionWithTypeArguments {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSExpressionWithTypeArguments {
     if (
       !isNode(node) ||
       !t.isTSExpressionWithTypeArguments(node)
@@ -9158,7 +9158,7 @@ export class TSExpressionWithTypeArgumentsMatcher extends Matcher<t.TSExpression
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -9171,7 +9171,7 @@ export class TSExpressionWithTypeArgumentsMatcher extends Matcher<t.TSExpression
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -9199,7 +9199,7 @@ export class TSInterfaceDeclarationMatcher extends Matcher<t.TSInterfaceDeclarat
     super();
   }
 
-  match(node: unknown): node is t.TSInterfaceDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSInterfaceDeclaration {
     if (
       !isNode(node) ||
       !t.isTSInterfaceDeclaration(node)
@@ -9209,7 +9209,7 @@ export class TSInterfaceDeclarationMatcher extends Matcher<t.TSInterfaceDeclarat
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -9222,7 +9222,7 @@ export class TSInterfaceDeclarationMatcher extends Matcher<t.TSInterfaceDeclarat
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -9236,16 +9236,16 @@ export class TSInterfaceDeclarationMatcher extends Matcher<t.TSInterfaceDeclarat
     } else if (node.extends === null) {
       return false;
     } else if (Array.isArray(this._extends)) {
-      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+      if (!tupleOf<unknown>(...this._extends).matchValue(node.extends, [...keys, 'extends'])) {
         return false;
       }
-    } else if (!this._extends.match(node.extends)) {
+    } else if (!this._extends.matchValue(node.extends, [...keys, 'extends'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -9274,7 +9274,7 @@ export class TSInterfaceBodyMatcher extends Matcher<t.TSInterfaceBody> {
     super();
   }
 
-  match(node: unknown): node is t.TSInterfaceBody {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSInterfaceBody {
     if (
       !isNode(node) ||
       !t.isTSInterfaceBody(node)
@@ -9285,10 +9285,10 @@ export class TSInterfaceBodyMatcher extends Matcher<t.TSInterfaceBody> {
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.body)) {
-      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+      if (!tupleOf<unknown>(...this.body).matchValue(node.body, [...keys, 'body'])) {
         return false;
       }
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -9313,7 +9313,7 @@ export class TSTypeAliasDeclarationMatcher extends Matcher<t.TSTypeAliasDeclarat
     super();
   }
 
-  match(node: unknown): node is t.TSTypeAliasDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeAliasDeclaration {
     if (
       !isNode(node) ||
       !t.isTSTypeAliasDeclaration(node)
@@ -9323,7 +9323,7 @@ export class TSTypeAliasDeclarationMatcher extends Matcher<t.TSTypeAliasDeclarat
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -9336,13 +9336,13 @@ export class TSTypeAliasDeclarationMatcher extends Matcher<t.TSTypeAliasDeclarat
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -9370,7 +9370,7 @@ export class TSAsExpressionMatcher extends Matcher<t.TSAsExpression> {
     super();
   }
 
-  match(node: unknown): node is t.TSAsExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSAsExpression {
     if (
       !isNode(node) ||
       !t.isTSAsExpression(node)
@@ -9380,13 +9380,13 @@ export class TSAsExpressionMatcher extends Matcher<t.TSAsExpression> {
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -9412,7 +9412,7 @@ export class TSTypeAssertionMatcher extends Matcher<t.TSTypeAssertion> {
     super();
   }
 
-  match(node: unknown): node is t.TSTypeAssertion {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeAssertion {
     if (
       !isNode(node) ||
       !t.isTSTypeAssertion(node)
@@ -9422,13 +9422,13 @@ export class TSTypeAssertionMatcher extends Matcher<t.TSTypeAssertion> {
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -9454,7 +9454,7 @@ export class TSEnumDeclarationMatcher extends Matcher<t.TSEnumDeclaration> {
     super();
   }
 
-  match(node: unknown): node is t.TSEnumDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSEnumDeclaration {
     if (
       !isNode(node) ||
       !t.isTSEnumDeclaration(node)
@@ -9464,17 +9464,17 @@ export class TSEnumDeclarationMatcher extends Matcher<t.TSEnumDeclaration> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.members === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.members)) {
-      if (!tupleOf<unknown>(...this.members).match(node.members)) {
+      if (!tupleOf<unknown>(...this.members).matchValue(node.members, [...keys, 'members'])) {
         return false;
       }
-    } else if (!this.members.match(node.members)) {
+    } else if (!this.members.matchValue(node.members, [...keys, 'members'])) {
       return false;
     }
 
@@ -9500,7 +9500,7 @@ export class TSEnumMemberMatcher extends Matcher<t.TSEnumMember> {
     super();
   }
 
-  match(node: unknown): node is t.TSEnumMember {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSEnumMember {
     if (
       !isNode(node) ||
       !t.isTSEnumMember(node)
@@ -9510,7 +9510,7 @@ export class TSEnumMemberMatcher extends Matcher<t.TSEnumMember> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -9523,7 +9523,7 @@ export class TSEnumMemberMatcher extends Matcher<t.TSEnumMember> {
       }
     } else if (node.initializer === null) {
       return false;
-    } else if (!this.initializer.match(node.initializer)) {
+    } else if (!this.initializer.matchValue(node.initializer, [...keys, 'initializer'])) {
       return false;
     }
 
@@ -9549,7 +9549,7 @@ export class TSModuleDeclarationMatcher extends Matcher<t.TSModuleDeclaration> {
     super();
   }
 
-  match(node: unknown): node is t.TSModuleDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSModuleDeclaration {
     if (
       !isNode(node) ||
       !t.isTSModuleDeclaration(node)
@@ -9559,13 +9559,13 @@ export class TSModuleDeclarationMatcher extends Matcher<t.TSModuleDeclaration> {
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -9590,7 +9590,7 @@ export class TSModuleBlockMatcher extends Matcher<t.TSModuleBlock> {
     super();
   }
 
-  match(node: unknown): node is t.TSModuleBlock {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSModuleBlock {
     if (
       !isNode(node) ||
       !t.isTSModuleBlock(node)
@@ -9601,10 +9601,10 @@ export class TSModuleBlockMatcher extends Matcher<t.TSModuleBlock> {
     if (typeof this.body === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.body)) {
-      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+      if (!tupleOf<unknown>(...this.body).matchValue(node.body, [...keys, 'body'])) {
         return false;
       }
-    } else if (!this.body.match(node.body)) {
+    } else if (!this.body.matchValue(node.body, [...keys, 'body'])) {
       return false;
     }
 
@@ -9629,7 +9629,7 @@ export class TSImportTypeMatcher extends Matcher<t.TSImportType> {
     super();
   }
 
-  match(node: unknown): node is t.TSImportType {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSImportType {
     if (
       !isNode(node) ||
       !t.isTSImportType(node)
@@ -9639,7 +9639,7 @@ export class TSImportTypeMatcher extends Matcher<t.TSImportType> {
 
     if (typeof this.argument === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.argument.match(node.argument)) {
+    } else if (!this.argument.matchValue(node.argument, [...keys, 'argument'])) {
       return false;
     }
 
@@ -9652,7 +9652,7 @@ export class TSImportTypeMatcher extends Matcher<t.TSImportType> {
       }
     } else if (node.qualifier === null) {
       return false;
-    } else if (!this.qualifier.match(node.qualifier)) {
+    } else if (!this.qualifier.matchValue(node.qualifier, [...keys, 'qualifier'])) {
       return false;
     }
 
@@ -9665,7 +9665,7 @@ export class TSImportTypeMatcher extends Matcher<t.TSImportType> {
       }
     } else if (node.typeParameters === null) {
       return false;
-    } else if (!this.typeParameters.match(node.typeParameters)) {
+    } else if (!this.typeParameters.matchValue(node.typeParameters, [...keys, 'typeParameters'])) {
       return false;
     }
 
@@ -9693,7 +9693,7 @@ export class TSImportEqualsDeclarationMatcher extends Matcher<t.TSImportEqualsDe
     super();
   }
 
-  match(node: unknown): node is t.TSImportEqualsDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSImportEqualsDeclaration {
     if (
       !isNode(node) ||
       !t.isTSImportEqualsDeclaration(node)
@@ -9703,13 +9703,13 @@ export class TSImportEqualsDeclarationMatcher extends Matcher<t.TSImportEqualsDe
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
     if (typeof this.moduleReference === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.moduleReference.match(node.moduleReference)) {
+    } else if (!this.moduleReference.matchValue(node.moduleReference, [...keys, 'moduleReference'])) {
       return false;
     }
 
@@ -9734,7 +9734,7 @@ export class TSExternalModuleReferenceMatcher extends Matcher<t.TSExternalModule
     super();
   }
 
-  match(node: unknown): node is t.TSExternalModuleReference {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSExternalModuleReference {
     if (
       !isNode(node) ||
       !t.isTSExternalModuleReference(node)
@@ -9744,7 +9744,7 @@ export class TSExternalModuleReferenceMatcher extends Matcher<t.TSExternalModule
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -9767,7 +9767,7 @@ export class TSNonNullExpressionMatcher extends Matcher<t.TSNonNullExpression> {
     super();
   }
 
-  match(node: unknown): node is t.TSNonNullExpression {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSNonNullExpression {
     if (
       !isNode(node) ||
       !t.isTSNonNullExpression(node)
@@ -9777,7 +9777,7 @@ export class TSNonNullExpressionMatcher extends Matcher<t.TSNonNullExpression> {
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -9800,7 +9800,7 @@ export class TSExportAssignmentMatcher extends Matcher<t.TSExportAssignment> {
     super();
   }
 
-  match(node: unknown): node is t.TSExportAssignment {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSExportAssignment {
     if (
       !isNode(node) ||
       !t.isTSExportAssignment(node)
@@ -9810,7 +9810,7 @@ export class TSExportAssignmentMatcher extends Matcher<t.TSExportAssignment> {
 
     if (typeof this.expression === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.expression.match(node.expression)) {
+    } else if (!this.expression.matchValue(node.expression, [...keys, 'expression'])) {
       return false;
     }
 
@@ -9833,7 +9833,7 @@ export class TSNamespaceExportDeclarationMatcher extends Matcher<t.TSNamespaceEx
     super();
   }
 
-  match(node: unknown): node is t.TSNamespaceExportDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSNamespaceExportDeclaration {
     if (
       !isNode(node) ||
       !t.isTSNamespaceExportDeclaration(node)
@@ -9843,7 +9843,7 @@ export class TSNamespaceExportDeclarationMatcher extends Matcher<t.TSNamespaceEx
 
     if (typeof this.id === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.id.match(node.id)) {
+    } else if (!this.id.matchValue(node.id, [...keys, 'id'])) {
       return false;
     }
 
@@ -9866,7 +9866,7 @@ export class TSTypeAnnotationMatcher extends Matcher<t.TSTypeAnnotation> {
     super();
   }
 
-  match(node: unknown): node is t.TSTypeAnnotation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeAnnotation {
     if (
       !isNode(node) ||
       !t.isTSTypeAnnotation(node)
@@ -9876,7 +9876,7 @@ export class TSTypeAnnotationMatcher extends Matcher<t.TSTypeAnnotation> {
 
     if (typeof this.typeAnnotation === 'undefined') {
       // undefined matcher means anything matches
-    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+    } else if (!this.typeAnnotation.matchValue(node.typeAnnotation, [...keys, 'typeAnnotation'])) {
       return false;
     }
 
@@ -9899,7 +9899,7 @@ export class TSTypeParameterInstantiationMatcher extends Matcher<t.TSTypeParamet
     super();
   }
 
-  match(node: unknown): node is t.TSTypeParameterInstantiation {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeParameterInstantiation {
     if (
       !isNode(node) ||
       !t.isTSTypeParameterInstantiation(node)
@@ -9910,10 +9910,10 @@ export class TSTypeParameterInstantiationMatcher extends Matcher<t.TSTypeParamet
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
@@ -9936,7 +9936,7 @@ export class TSTypeParameterDeclarationMatcher extends Matcher<t.TSTypeParameter
     super();
   }
 
-  match(node: unknown): node is t.TSTypeParameterDeclaration {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeParameterDeclaration {
     if (
       !isNode(node) ||
       !t.isTSTypeParameterDeclaration(node)
@@ -9947,10 +9947,10 @@ export class TSTypeParameterDeclarationMatcher extends Matcher<t.TSTypeParameter
     if (typeof this.params === 'undefined') {
       // undefined matcher means anything matches
     } else if (Array.isArray(this.params)) {
-      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+      if (!tupleOf<unknown>(...this.params).matchValue(node.params, [...keys, 'params'])) {
         return false;
       }
-    } else if (!this.params.match(node.params)) {
+    } else if (!this.params.matchValue(node.params, [...keys, 'params'])) {
       return false;
     }
 
@@ -9974,7 +9974,7 @@ export class TSTypeParameterMatcher extends Matcher<t.TSTypeParameter> {
     super();
   }
 
-  match(node: unknown): node is t.TSTypeParameter {
+  matchValue(node: unknown, keys: ReadonlyArray<PropertyKey>): node is t.TSTypeParameter {
     if (
       !isNode(node) ||
       !t.isTSTypeParameter(node)
@@ -9991,7 +9991,7 @@ export class TSTypeParameterMatcher extends Matcher<t.TSTypeParameter> {
       }
     } else if (node.constraint === null) {
       return false;
-    } else if (!this.constraint.match(node.constraint)) {
+    } else if (!this.constraint.matchValue(node.constraint, [...keys, 'constraint'])) {
       return false;
     }
 
@@ -10004,7 +10004,7 @@ export class TSTypeParameterMatcher extends Matcher<t.TSTypeParameter> {
       }
     } else if (node.default === null) {
       return false;
-    } else if (!this._default.match(node.default)) {
+    } else if (!this._default.matchValue(node.default, [...keys, 'default'])) {
       return false;
     }
 

--- a/packages/matchers/src/matchers.ts
+++ b/packages/matchers/src/matchers.ts
@@ -1,0 +1,10024 @@
+/* eslint-disable */
+import * as t from '@babel/types';
+
+export * from './matchers/spacers';
+export { default as Function } from './matchers/Function';
+export { default as Matcher } from './matchers/Matcher';
+export { default as anyExpression } from './matchers/anyExpression';
+export { default as anyList } from './matchers/anyList';
+export { default as anyNode } from './matchers/anyNode';
+export { default as anyNumber } from './matchers/anyNumber';
+export { default as anyStatement } from './matchers/anyStatement';
+export { default as anyString } from './matchers/anyString';
+export { default as anything } from './matchers/anything';
+export { default as arrayOf } from './matchers/arrayOf';
+export { default as capture, CapturedMatcher } from './matchers/capture';
+export { default as containerOf } from './matchers/containerOf';
+export { default as fromCapture } from './matchers/fromCapture';
+export { default as function } from './matchers/Function';
+export { default as oneOf } from './matchers/oneOf';
+export { default as or } from './matchers/or';
+export { default as matcher } from './matchers/predicate';
+export { default as tupleOf } from './matchers/tupleOf';
+
+import tupleOf from './matchers/tupleOf';
+import { isNode } from './NodeTypes';
+import Matcher from './matchers/Matcher';
+
+// aliases for keyword-named functions
+export { Import as import }
+export { Super as super }
+
+export class ArrayExpressionMatcher extends Matcher<t.ArrayExpression> {
+  constructor(
+    private readonly elements?: Matcher<Array<null | t.Expression | t.SpreadElement>> | Array<Matcher<null> | Matcher<t.Expression> | Matcher<t.SpreadElement>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ArrayExpression {
+    if (
+      !isNode(node) ||
+      !t.isArrayExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.elements === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.elements)) {
+      if (!tupleOf<unknown>(...this.elements).match(node.elements)) {
+        return false;
+      }
+    } else if (!this.elements.match(node.elements)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function arrayExpression(
+  elements?: Matcher<Array<null | t.Expression | t.SpreadElement>> | Array<Matcher<null> | Matcher<t.Expression> | Matcher<t.SpreadElement>>,
+): Matcher<t.ArrayExpression> {
+  return new ArrayExpressionMatcher(
+    elements,
+  );
+}
+
+export class AssignmentExpressionMatcher extends Matcher<t.AssignmentExpression> {
+  constructor(
+    private readonly operator?: Matcher<string> | string,
+    private readonly left?: Matcher<t.LVal>,
+    private readonly right?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.AssignmentExpression {
+    if (
+      !isNode(node) ||
+      !t.isAssignmentExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.operator === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.operator === 'string') {
+      if (this.operator !== node.operator) {
+        return false;
+      }
+    } else if (!this.operator.match(node.operator)) {
+      return false;
+    }
+
+    if (typeof this.left === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.left.match(node.left)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function assignmentExpression(
+  operator?: Matcher<string> | string,
+  left?: Matcher<t.LVal>,
+  right?: Matcher<t.Expression>,
+): Matcher<t.AssignmentExpression> {
+  return new AssignmentExpressionMatcher(
+    operator,
+    left,
+    right,
+  );
+}
+
+export class BinaryExpressionMatcher extends Matcher<t.BinaryExpression> {
+  constructor(
+    private readonly operator?: Matcher<"+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<="> | string,
+    private readonly left?: Matcher<t.Expression>,
+    private readonly right?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.BinaryExpression {
+    if (
+      !isNode(node) ||
+      !t.isBinaryExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.operator === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.operator === 'string') {
+      if (this.operator !== node.operator) {
+        return false;
+      }
+    } else if (!this.operator.match(node.operator)) {
+      return false;
+    }
+
+    if (typeof this.left === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.left.match(node.left)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function binaryExpression(
+  operator?: Matcher<"+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<="> | string,
+  left?: Matcher<t.Expression>,
+  right?: Matcher<t.Expression>,
+): Matcher<t.BinaryExpression> {
+  return new BinaryExpressionMatcher(
+    operator,
+    left,
+    right,
+  );
+}
+
+export class InterpreterDirectiveMatcher extends Matcher<t.InterpreterDirective> {
+  constructor(
+    private readonly value?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.InterpreterDirective {
+    if (
+      !isNode(node) ||
+      !t.isInterpreterDirective(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'string') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function interpreterDirective(
+  value?: Matcher<string> | string,
+): Matcher<t.InterpreterDirective> {
+  return new InterpreterDirectiveMatcher(
+    value,
+  );
+}
+
+export class DirectiveMatcher extends Matcher<t.Directive> {
+  constructor(
+    private readonly value?: Matcher<t.DirectiveLiteral>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.Directive {
+    if (
+      !isNode(node) ||
+      !t.isDirective(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function directive(
+  value?: Matcher<t.DirectiveLiteral>,
+): Matcher<t.Directive> {
+  return new DirectiveMatcher(
+    value,
+  );
+}
+
+export class DirectiveLiteralMatcher extends Matcher<t.DirectiveLiteral> {
+  constructor(
+    private readonly value?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DirectiveLiteral {
+    if (
+      !isNode(node) ||
+      !t.isDirectiveLiteral(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'string') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function directiveLiteral(
+  value?: Matcher<string> | string,
+): Matcher<t.DirectiveLiteral> {
+  return new DirectiveLiteralMatcher(
+    value,
+  );
+}
+
+export class BlockStatementMatcher extends Matcher<t.BlockStatement> {
+  constructor(
+    private readonly body?: Matcher<Array<t.Statement>> | Array<Matcher<t.Statement>>,
+    private readonly directives?: Matcher<Array<t.Directive>> | Array<Matcher<t.Directive>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.BlockStatement {
+    if (
+      !isNode(node) ||
+      !t.isBlockStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.body)) {
+      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+        return false;
+      }
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.directives === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.directives)) {
+      if (!tupleOf<unknown>(...this.directives).match(node.directives)) {
+        return false;
+      }
+    } else if (!this.directives.match(node.directives)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function blockStatement(
+  body?: Matcher<Array<t.Statement>> | Array<Matcher<t.Statement>>,
+  directives?: Matcher<Array<t.Directive>> | Array<Matcher<t.Directive>>,
+): Matcher<t.BlockStatement> {
+  return new BlockStatementMatcher(
+    body,
+    directives,
+  );
+}
+
+export class BreakStatementMatcher extends Matcher<t.BreakStatement> {
+  constructor(
+    private readonly label?: Matcher<t.Identifier> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.BreakStatement {
+    if (
+      !isNode(node) ||
+      !t.isBreakStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.label === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.label === null) {
+      // null matcher means we expect null value
+      if (node.label !== null) {
+        return false;
+      }
+    } else if (node.label === null) {
+      return false;
+    } else if (!this.label.match(node.label)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function breakStatement(
+  label?: Matcher<t.Identifier> | null,
+): Matcher<t.BreakStatement> {
+  return new BreakStatementMatcher(
+    label,
+  );
+}
+
+export class CallExpressionMatcher extends Matcher<t.CallExpression> {
+  constructor(
+    private readonly callee?: Matcher<t.Expression>,
+    private readonly _arguments?: Matcher<Array<t.Expression | t.SpreadElement | t.JSXNamespacedName>> | Array<Matcher<t.Expression> | Matcher<t.SpreadElement> | Matcher<t.JSXNamespacedName>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.CallExpression {
+    if (
+      !isNode(node) ||
+      !t.isCallExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.callee === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.callee.match(node.callee)) {
+      return false;
+    }
+
+    if (typeof this._arguments === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this._arguments)) {
+      if (!tupleOf<unknown>(...this._arguments).match(node.arguments)) {
+        return false;
+      }
+    } else if (!this._arguments.match(node.arguments)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function callExpression(
+  callee?: Matcher<t.Expression>,
+  _arguments?: Matcher<Array<t.Expression | t.SpreadElement | t.JSXNamespacedName>> | Array<Matcher<t.Expression> | Matcher<t.SpreadElement> | Matcher<t.JSXNamespacedName>>,
+): Matcher<t.CallExpression> {
+  return new CallExpressionMatcher(
+    callee,
+    _arguments,
+  );
+}
+
+export class CatchClauseMatcher extends Matcher<t.CatchClause> {
+  constructor(
+    private readonly param?: Matcher<t.Identifier> | null,
+    private readonly body?: Matcher<t.BlockStatement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.CatchClause {
+    if (
+      !isNode(node) ||
+      !t.isCatchClause(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.param === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.param === null) {
+      // null matcher means we expect null value
+      if (node.param !== null) {
+        return false;
+      }
+    } else if (node.param === null) {
+      return false;
+    } else if (!this.param.match(node.param)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function catchClause(
+  param?: Matcher<t.Identifier> | null,
+  body?: Matcher<t.BlockStatement>,
+): Matcher<t.CatchClause> {
+  return new CatchClauseMatcher(
+    param,
+    body,
+  );
+}
+
+export class ConditionalExpressionMatcher extends Matcher<t.ConditionalExpression> {
+  constructor(
+    private readonly test?: Matcher<t.Expression>,
+    private readonly consequent?: Matcher<t.Expression>,
+    private readonly alternate?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ConditionalExpression {
+    if (
+      !isNode(node) ||
+      !t.isConditionalExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.test === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.test.match(node.test)) {
+      return false;
+    }
+
+    if (typeof this.consequent === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.consequent.match(node.consequent)) {
+      return false;
+    }
+
+    if (typeof this.alternate === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.alternate.match(node.alternate)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function conditionalExpression(
+  test?: Matcher<t.Expression>,
+  consequent?: Matcher<t.Expression>,
+  alternate?: Matcher<t.Expression>,
+): Matcher<t.ConditionalExpression> {
+  return new ConditionalExpressionMatcher(
+    test,
+    consequent,
+    alternate,
+  );
+}
+
+export class ContinueStatementMatcher extends Matcher<t.ContinueStatement> {
+  constructor(
+    private readonly label?: Matcher<t.Identifier> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ContinueStatement {
+    if (
+      !isNode(node) ||
+      !t.isContinueStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.label === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.label === null) {
+      // null matcher means we expect null value
+      if (node.label !== null) {
+        return false;
+      }
+    } else if (node.label === null) {
+      return false;
+    } else if (!this.label.match(node.label)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function continueStatement(
+  label?: Matcher<t.Identifier> | null,
+): Matcher<t.ContinueStatement> {
+  return new ContinueStatementMatcher(
+    label,
+  );
+}
+
+export class DebuggerStatementMatcher extends Matcher<t.DebuggerStatement> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DebuggerStatement {
+    if (
+      !isNode(node) ||
+      !t.isDebuggerStatement(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function debuggerStatement(
+): Matcher<t.DebuggerStatement> {
+  return new DebuggerStatementMatcher(
+  );
+}
+
+export class DoWhileStatementMatcher extends Matcher<t.DoWhileStatement> {
+  constructor(
+    private readonly test?: Matcher<t.Expression>,
+    private readonly body?: Matcher<t.Statement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DoWhileStatement {
+    if (
+      !isNode(node) ||
+      !t.isDoWhileStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.test === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.test.match(node.test)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function doWhileStatement(
+  test?: Matcher<t.Expression>,
+  body?: Matcher<t.Statement>,
+): Matcher<t.DoWhileStatement> {
+  return new DoWhileStatementMatcher(
+    test,
+    body,
+  );
+}
+
+export class EmptyStatementMatcher extends Matcher<t.EmptyStatement> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.EmptyStatement {
+    if (
+      !isNode(node) ||
+      !t.isEmptyStatement(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function emptyStatement(
+): Matcher<t.EmptyStatement> {
+  return new EmptyStatementMatcher(
+  );
+}
+
+export class ExpressionStatementMatcher extends Matcher<t.ExpressionStatement> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ExpressionStatement {
+    if (
+      !isNode(node) ||
+      !t.isExpressionStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function expressionStatement(
+  expression?: Matcher<t.Expression>,
+): Matcher<t.ExpressionStatement> {
+  return new ExpressionStatementMatcher(
+    expression,
+  );
+}
+
+export class FileMatcher extends Matcher<t.File> {
+  constructor(
+    private readonly program?: Matcher<t.Program>,
+    private readonly comments?: Matcher<any>,
+    private readonly tokens?: Matcher<any>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.File {
+    if (
+      !isNode(node) ||
+      !t.isFile(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.program === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.program.match(node.program)) {
+      return false;
+    }
+
+    if (typeof this.comments === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.comments.match(node.comments)) {
+      return false;
+    }
+
+    if (typeof this.tokens === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.tokens.match(node.tokens)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function file(
+  program?: Matcher<t.Program>,
+  comments?: Matcher<any>,
+  tokens?: Matcher<any>,
+): Matcher<t.File> {
+  return new FileMatcher(
+    program,
+    comments,
+    tokens,
+  );
+}
+
+export class ForInStatementMatcher extends Matcher<t.ForInStatement> {
+  constructor(
+    private readonly left?: Matcher<t.VariableDeclaration | t.LVal>,
+    private readonly right?: Matcher<t.Expression>,
+    private readonly body?: Matcher<t.Statement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ForInStatement {
+    if (
+      !isNode(node) ||
+      !t.isForInStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.left === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.left.match(node.left)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function forInStatement(
+  left?: Matcher<t.VariableDeclaration | t.LVal>,
+  right?: Matcher<t.Expression>,
+  body?: Matcher<t.Statement>,
+): Matcher<t.ForInStatement> {
+  return new ForInStatementMatcher(
+    left,
+    right,
+    body,
+  );
+}
+
+export class ForStatementMatcher extends Matcher<t.ForStatement> {
+  constructor(
+    private readonly init?: Matcher<t.VariableDeclaration | t.Expression> | null,
+    private readonly test?: Matcher<t.Expression> | null,
+    private readonly update?: Matcher<t.Expression> | null,
+    private readonly body?: Matcher<t.Statement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ForStatement {
+    if (
+      !isNode(node) ||
+      !t.isForStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.init === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.init === null) {
+      // null matcher means we expect null value
+      if (node.init !== null) {
+        return false;
+      }
+    } else if (node.init === null) {
+      return false;
+    } else if (!this.init.match(node.init)) {
+      return false;
+    }
+
+    if (typeof this.test === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.test === null) {
+      // null matcher means we expect null value
+      if (node.test !== null) {
+        return false;
+      }
+    } else if (node.test === null) {
+      return false;
+    } else if (!this.test.match(node.test)) {
+      return false;
+    }
+
+    if (typeof this.update === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.update === null) {
+      // null matcher means we expect null value
+      if (node.update !== null) {
+        return false;
+      }
+    } else if (node.update === null) {
+      return false;
+    } else if (!this.update.match(node.update)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function forStatement(
+  init?: Matcher<t.VariableDeclaration | t.Expression> | null,
+  test?: Matcher<t.Expression> | null,
+  update?: Matcher<t.Expression> | null,
+  body?: Matcher<t.Statement>,
+): Matcher<t.ForStatement> {
+  return new ForStatementMatcher(
+    init,
+    test,
+    update,
+    body,
+  );
+}
+
+export class FunctionDeclarationMatcher extends Matcher<t.FunctionDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier> | null,
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly body?: Matcher<t.BlockStatement>,
+    private readonly generator?: Matcher<boolean> | boolean | null,
+    private readonly async?: Matcher<boolean> | boolean | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.FunctionDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isFunctionDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.id === null) {
+      // null matcher means we expect null value
+      if (node.id !== null) {
+        return false;
+      }
+    } else if (node.id === null) {
+      return false;
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.generator === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.generator === 'boolean') {
+      if (this.generator !== node.generator) {
+        return false;
+      }
+    } else if (this.generator === null) {
+      // null matcher means we expect null value
+      if (node.generator !== null) {
+        return false;
+      }
+    } else if (node.generator === null) {
+      return false;
+    } else if (!this.generator.match(node.generator)) {
+      return false;
+    }
+
+    if (typeof this.async === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.async === 'boolean') {
+      if (this.async !== node.async) {
+        return false;
+      }
+    } else if (this.async === null) {
+      // null matcher means we expect null value
+      if (node.async !== null) {
+        return false;
+      }
+    } else if (node.async === null) {
+      return false;
+    } else if (!this.async.match(node.async)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function functionDeclaration(
+  id?: Matcher<t.Identifier> | null,
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  body?: Matcher<t.BlockStatement>,
+  generator?: Matcher<boolean> | boolean | null,
+  async?: Matcher<boolean> | boolean | null,
+): Matcher<t.FunctionDeclaration> {
+  return new FunctionDeclarationMatcher(
+    id,
+    params,
+    body,
+    generator,
+    async,
+  );
+}
+
+export class FunctionExpressionMatcher extends Matcher<t.FunctionExpression> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier> | null,
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly body?: Matcher<t.BlockStatement>,
+    private readonly generator?: Matcher<boolean> | boolean | null,
+    private readonly async?: Matcher<boolean> | boolean | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.FunctionExpression {
+    if (
+      !isNode(node) ||
+      !t.isFunctionExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.id === null) {
+      // null matcher means we expect null value
+      if (node.id !== null) {
+        return false;
+      }
+    } else if (node.id === null) {
+      return false;
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.generator === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.generator === 'boolean') {
+      if (this.generator !== node.generator) {
+        return false;
+      }
+    } else if (this.generator === null) {
+      // null matcher means we expect null value
+      if (node.generator !== null) {
+        return false;
+      }
+    } else if (node.generator === null) {
+      return false;
+    } else if (!this.generator.match(node.generator)) {
+      return false;
+    }
+
+    if (typeof this.async === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.async === 'boolean') {
+      if (this.async !== node.async) {
+        return false;
+      }
+    } else if (this.async === null) {
+      // null matcher means we expect null value
+      if (node.async !== null) {
+        return false;
+      }
+    } else if (node.async === null) {
+      return false;
+    } else if (!this.async.match(node.async)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function functionExpression(
+  id?: Matcher<t.Identifier> | null,
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  body?: Matcher<t.BlockStatement>,
+  generator?: Matcher<boolean> | boolean | null,
+  async?: Matcher<boolean> | boolean | null,
+): Matcher<t.FunctionExpression> {
+  return new FunctionExpressionMatcher(
+    id,
+    params,
+    body,
+    generator,
+    async,
+  );
+}
+
+export class IdentifierMatcher extends Matcher<t.Identifier> {
+  constructor(
+    private readonly name?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.Identifier {
+    if (
+      !isNode(node) ||
+      !t.isIdentifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.name === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.name === 'string') {
+      if (this.name !== node.name) {
+        return false;
+      }
+    } else if (!this.name.match(node.name)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function identifier(
+  name?: Matcher<string> | string,
+): Matcher<t.Identifier> {
+  return new IdentifierMatcher(
+    name,
+  );
+}
+
+export class IfStatementMatcher extends Matcher<t.IfStatement> {
+  constructor(
+    private readonly test?: Matcher<t.Expression>,
+    private readonly consequent?: Matcher<t.Statement>,
+    private readonly alternate?: Matcher<t.Statement> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.IfStatement {
+    if (
+      !isNode(node) ||
+      !t.isIfStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.test === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.test.match(node.test)) {
+      return false;
+    }
+
+    if (typeof this.consequent === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.consequent.match(node.consequent)) {
+      return false;
+    }
+
+    if (typeof this.alternate === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.alternate === null) {
+      // null matcher means we expect null value
+      if (node.alternate !== null) {
+        return false;
+      }
+    } else if (node.alternate === null) {
+      return false;
+    } else if (!this.alternate.match(node.alternate)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function ifStatement(
+  test?: Matcher<t.Expression>,
+  consequent?: Matcher<t.Statement>,
+  alternate?: Matcher<t.Statement> | null,
+): Matcher<t.IfStatement> {
+  return new IfStatementMatcher(
+    test,
+    consequent,
+    alternate,
+  );
+}
+
+export class LabeledStatementMatcher extends Matcher<t.LabeledStatement> {
+  constructor(
+    private readonly label?: Matcher<t.Identifier>,
+    private readonly body?: Matcher<t.Statement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.LabeledStatement {
+    if (
+      !isNode(node) ||
+      !t.isLabeledStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.label === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.label.match(node.label)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function labeledStatement(
+  label?: Matcher<t.Identifier>,
+  body?: Matcher<t.Statement>,
+): Matcher<t.LabeledStatement> {
+  return new LabeledStatementMatcher(
+    label,
+    body,
+  );
+}
+
+export class StringLiteralMatcher extends Matcher<t.StringLiteral> {
+  constructor(
+    private readonly value?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.StringLiteral {
+    if (
+      !isNode(node) ||
+      !t.isStringLiteral(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'string') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function stringLiteral(
+  value?: Matcher<string> | string,
+): Matcher<t.StringLiteral> {
+  return new StringLiteralMatcher(
+    value,
+  );
+}
+
+export class NumericLiteralMatcher extends Matcher<t.NumericLiteral> {
+  constructor(
+    private readonly value?: Matcher<number> | number,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.NumericLiteral {
+    if (
+      !isNode(node) ||
+      !t.isNumericLiteral(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'number') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function numericLiteral(
+  value?: Matcher<number> | number,
+): Matcher<t.NumericLiteral> {
+  return new NumericLiteralMatcher(
+    value,
+  );
+}
+
+export class NullLiteralMatcher extends Matcher<t.NullLiteral> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.NullLiteral {
+    if (
+      !isNode(node) ||
+      !t.isNullLiteral(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function nullLiteral(
+): Matcher<t.NullLiteral> {
+  return new NullLiteralMatcher(
+  );
+}
+
+export class BooleanLiteralMatcher extends Matcher<t.BooleanLiteral> {
+  constructor(
+    private readonly value?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.BooleanLiteral {
+    if (
+      !isNode(node) ||
+      !t.isBooleanLiteral(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'boolean') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function booleanLiteral(
+  value?: Matcher<boolean> | boolean,
+): Matcher<t.BooleanLiteral> {
+  return new BooleanLiteralMatcher(
+    value,
+  );
+}
+
+export class RegExpLiteralMatcher extends Matcher<t.RegExpLiteral> {
+  constructor(
+    private readonly pattern?: Matcher<string> | string,
+    private readonly flags?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.RegExpLiteral {
+    if (
+      !isNode(node) ||
+      !t.isRegExpLiteral(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.pattern === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.pattern === 'string') {
+      if (this.pattern !== node.pattern) {
+        return false;
+      }
+    } else if (!this.pattern.match(node.pattern)) {
+      return false;
+    }
+
+    if (typeof this.flags === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.flags === 'string') {
+      if (this.flags !== node.flags) {
+        return false;
+      }
+    } else if (!this.flags.match(node.flags)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function regExpLiteral(
+  pattern?: Matcher<string> | string,
+  flags?: Matcher<string> | string,
+): Matcher<t.RegExpLiteral> {
+  return new RegExpLiteralMatcher(
+    pattern,
+    flags,
+  );
+}
+
+export class LogicalExpressionMatcher extends Matcher<t.LogicalExpression> {
+  constructor(
+    private readonly operator?: Matcher<"||" | "&&" | "??"> | string,
+    private readonly left?: Matcher<t.Expression>,
+    private readonly right?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.LogicalExpression {
+    if (
+      !isNode(node) ||
+      !t.isLogicalExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.operator === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.operator === 'string') {
+      if (this.operator !== node.operator) {
+        return false;
+      }
+    } else if (!this.operator.match(node.operator)) {
+      return false;
+    }
+
+    if (typeof this.left === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.left.match(node.left)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function logicalExpression(
+  operator?: Matcher<"||" | "&&" | "??"> | string,
+  left?: Matcher<t.Expression>,
+  right?: Matcher<t.Expression>,
+): Matcher<t.LogicalExpression> {
+  return new LogicalExpressionMatcher(
+    operator,
+    left,
+    right,
+  );
+}
+
+export class MemberExpressionMatcher extends Matcher<t.MemberExpression> {
+  constructor(
+    private readonly object?: Matcher<t.Expression>,
+    private readonly property?: Matcher<any>,
+    private readonly computed?: Matcher<boolean> | boolean,
+    private readonly optional?: Matcher<true | false> | boolean | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.MemberExpression {
+    if (
+      !isNode(node) ||
+      !t.isMemberExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.object === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.object.match(node.object)) {
+      return false;
+    }
+
+    if (typeof this.property === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.property.match(node.property)) {
+      return false;
+    }
+
+    if (typeof this.computed === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.computed === 'boolean') {
+      if (this.computed !== node.computed) {
+        return false;
+      }
+    } else if (!this.computed.match(node.computed)) {
+      return false;
+    }
+
+    if (typeof this.optional === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.optional === 'boolean') {
+      if (this.optional !== node.optional) {
+        return false;
+      }
+    } else if (this.optional === null) {
+      // null matcher means we expect null value
+      if (node.optional !== null) {
+        return false;
+      }
+    } else if (node.optional === null) {
+      return false;
+    } else if (!this.optional.match(node.optional)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function memberExpression(
+  object?: Matcher<t.Expression>,
+  property?: Matcher<any>,
+  computed?: Matcher<boolean> | boolean,
+  optional?: Matcher<true | false> | boolean | null,
+): Matcher<t.MemberExpression> {
+  return new MemberExpressionMatcher(
+    object,
+    property,
+    computed,
+    optional,
+  );
+}
+
+export class NewExpressionMatcher extends Matcher<t.NewExpression> {
+  constructor(
+    private readonly callee?: Matcher<t.Expression>,
+    private readonly _arguments?: Matcher<Array<t.Expression | t.SpreadElement | t.JSXNamespacedName>> | Array<Matcher<t.Expression> | Matcher<t.SpreadElement> | Matcher<t.JSXNamespacedName>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.NewExpression {
+    if (
+      !isNode(node) ||
+      !t.isNewExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.callee === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.callee.match(node.callee)) {
+      return false;
+    }
+
+    if (typeof this._arguments === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this._arguments)) {
+      if (!tupleOf<unknown>(...this._arguments).match(node.arguments)) {
+        return false;
+      }
+    } else if (!this._arguments.match(node.arguments)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function newExpression(
+  callee?: Matcher<t.Expression>,
+  _arguments?: Matcher<Array<t.Expression | t.SpreadElement | t.JSXNamespacedName>> | Array<Matcher<t.Expression> | Matcher<t.SpreadElement> | Matcher<t.JSXNamespacedName>>,
+): Matcher<t.NewExpression> {
+  return new NewExpressionMatcher(
+    callee,
+    _arguments,
+  );
+}
+
+export class ProgramMatcher extends Matcher<t.Program> {
+  constructor(
+    private readonly body?: Matcher<Array<t.Statement>> | Array<Matcher<t.Statement>>,
+    private readonly directives?: Matcher<Array<t.Directive>> | Array<Matcher<t.Directive>>,
+    private readonly sourceType?: Matcher<"script" | "module"> | string,
+    private readonly interpreter?: Matcher<t.InterpreterDirective> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.Program {
+    if (
+      !isNode(node) ||
+      !t.isProgram(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.body)) {
+      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+        return false;
+      }
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.directives === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.directives)) {
+      if (!tupleOf<unknown>(...this.directives).match(node.directives)) {
+        return false;
+      }
+    } else if (!this.directives.match(node.directives)) {
+      return false;
+    }
+
+    if (typeof this.sourceType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.sourceType === 'string') {
+      if (this.sourceType !== node.sourceType) {
+        return false;
+      }
+    } else if (!this.sourceType.match(node.sourceType)) {
+      return false;
+    }
+
+    if (typeof this.interpreter === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.interpreter === null) {
+      // null matcher means we expect null value
+      if (node.interpreter !== null) {
+        return false;
+      }
+    } else if (node.interpreter === null) {
+      return false;
+    } else if (!this.interpreter.match(node.interpreter)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function program(
+  body?: Matcher<Array<t.Statement>> | Array<Matcher<t.Statement>>,
+  directives?: Matcher<Array<t.Directive>> | Array<Matcher<t.Directive>>,
+  sourceType?: Matcher<"script" | "module"> | string,
+  interpreter?: Matcher<t.InterpreterDirective> | null,
+): Matcher<t.Program> {
+  return new ProgramMatcher(
+    body,
+    directives,
+    sourceType,
+    interpreter,
+  );
+}
+
+export class ObjectExpressionMatcher extends Matcher<t.ObjectExpression> {
+  constructor(
+    private readonly properties?: Matcher<Array<t.ObjectMethod | t.ObjectProperty | t.SpreadElement>> | Array<Matcher<t.ObjectMethod> | Matcher<t.ObjectProperty> | Matcher<t.SpreadElement>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectExpression {
+    if (
+      !isNode(node) ||
+      !t.isObjectExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.properties === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.properties)) {
+      if (!tupleOf<unknown>(...this.properties).match(node.properties)) {
+        return false;
+      }
+    } else if (!this.properties.match(node.properties)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectExpression(
+  properties?: Matcher<Array<t.ObjectMethod | t.ObjectProperty | t.SpreadElement>> | Array<Matcher<t.ObjectMethod> | Matcher<t.ObjectProperty> | Matcher<t.SpreadElement>>,
+): Matcher<t.ObjectExpression> {
+  return new ObjectExpressionMatcher(
+    properties,
+  );
+}
+
+export class ObjectMethodMatcher extends Matcher<t.ObjectMethod> {
+  constructor(
+    private readonly kind?: Matcher<"method" | "get" | "set"> | string,
+    private readonly key?: Matcher<any>,
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly body?: Matcher<t.BlockStatement>,
+    private readonly computed?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectMethod {
+    if (
+      !isNode(node) ||
+      !t.isObjectMethod(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.kind === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.kind === 'string') {
+      if (this.kind !== node.kind) {
+        return false;
+      }
+    } else if (!this.kind.match(node.kind)) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.computed === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.computed === 'boolean') {
+      if (this.computed !== node.computed) {
+        return false;
+      }
+    } else if (!this.computed.match(node.computed)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectMethod(
+  kind?: Matcher<"method" | "get" | "set"> | string,
+  key?: Matcher<any>,
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  body?: Matcher<t.BlockStatement>,
+  computed?: Matcher<boolean> | boolean,
+): Matcher<t.ObjectMethod> {
+  return new ObjectMethodMatcher(
+    kind,
+    key,
+    params,
+    body,
+    computed,
+  );
+}
+
+export class ObjectPropertyMatcher extends Matcher<t.ObjectProperty> {
+  constructor(
+    private readonly key?: Matcher<any>,
+    private readonly value?: Matcher<t.Expression | t.PatternLike>,
+    private readonly computed?: Matcher<boolean> | boolean,
+    private readonly shorthand?: Matcher<boolean> | boolean,
+    private readonly decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectProperty {
+    if (
+      !isNode(node) ||
+      !t.isObjectProperty(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    if (typeof this.computed === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.computed === 'boolean') {
+      if (this.computed !== node.computed) {
+        return false;
+      }
+    } else if (!this.computed.match(node.computed)) {
+      return false;
+    }
+
+    if (typeof this.shorthand === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.shorthand === 'boolean') {
+      if (this.shorthand !== node.shorthand) {
+        return false;
+      }
+    } else if (!this.shorthand.match(node.shorthand)) {
+      return false;
+    }
+
+    if (typeof this.decorators === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.decorators === null) {
+      // null matcher means we expect null value
+      if (node.decorators !== null) {
+        return false;
+      }
+    } else if (node.decorators === null) {
+      return false;
+    } else if (Array.isArray(this.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+        return false;
+      }
+    } else if (!this.decorators.match(node.decorators)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectProperty(
+  key?: Matcher<any>,
+  value?: Matcher<t.Expression | t.PatternLike>,
+  computed?: Matcher<boolean> | boolean,
+  shorthand?: Matcher<boolean> | boolean,
+  decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+): Matcher<t.ObjectProperty> {
+  return new ObjectPropertyMatcher(
+    key,
+    value,
+    computed,
+    shorthand,
+    decorators,
+  );
+}
+
+export class RestElementMatcher extends Matcher<t.RestElement> {
+  constructor(
+    private readonly argument?: Matcher<t.LVal>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.RestElement {
+    if (
+      !isNode(node) ||
+      !t.isRestElement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function restElement(
+  argument?: Matcher<t.LVal>,
+): Matcher<t.RestElement> {
+  return new RestElementMatcher(
+    argument,
+  );
+}
+
+export class ReturnStatementMatcher extends Matcher<t.ReturnStatement> {
+  constructor(
+    private readonly argument?: Matcher<t.Expression> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ReturnStatement {
+    if (
+      !isNode(node) ||
+      !t.isReturnStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.argument === null) {
+      // null matcher means we expect null value
+      if (node.argument !== null) {
+        return false;
+      }
+    } else if (node.argument === null) {
+      return false;
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function returnStatement(
+  argument?: Matcher<t.Expression> | null,
+): Matcher<t.ReturnStatement> {
+  return new ReturnStatementMatcher(
+    argument,
+  );
+}
+
+export class SequenceExpressionMatcher extends Matcher<t.SequenceExpression> {
+  constructor(
+    private readonly expressions?: Matcher<Array<t.Expression>> | Array<Matcher<t.Expression>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.SequenceExpression {
+    if (
+      !isNode(node) ||
+      !t.isSequenceExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expressions === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.expressions)) {
+      if (!tupleOf<unknown>(...this.expressions).match(node.expressions)) {
+        return false;
+      }
+    } else if (!this.expressions.match(node.expressions)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function sequenceExpression(
+  expressions?: Matcher<Array<t.Expression>> | Array<Matcher<t.Expression>>,
+): Matcher<t.SequenceExpression> {
+  return new SequenceExpressionMatcher(
+    expressions,
+  );
+}
+
+export class SwitchCaseMatcher extends Matcher<t.SwitchCase> {
+  constructor(
+    private readonly test?: Matcher<t.Expression> | null,
+    private readonly consequent?: Matcher<Array<t.Statement>> | Array<Matcher<t.Statement>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.SwitchCase {
+    if (
+      !isNode(node) ||
+      !t.isSwitchCase(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.test === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.test === null) {
+      // null matcher means we expect null value
+      if (node.test !== null) {
+        return false;
+      }
+    } else if (node.test === null) {
+      return false;
+    } else if (!this.test.match(node.test)) {
+      return false;
+    }
+
+    if (typeof this.consequent === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.consequent)) {
+      if (!tupleOf<unknown>(...this.consequent).match(node.consequent)) {
+        return false;
+      }
+    } else if (!this.consequent.match(node.consequent)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function switchCase(
+  test?: Matcher<t.Expression> | null,
+  consequent?: Matcher<Array<t.Statement>> | Array<Matcher<t.Statement>>,
+): Matcher<t.SwitchCase> {
+  return new SwitchCaseMatcher(
+    test,
+    consequent,
+  );
+}
+
+export class SwitchStatementMatcher extends Matcher<t.SwitchStatement> {
+  constructor(
+    private readonly discriminant?: Matcher<t.Expression>,
+    private readonly cases?: Matcher<Array<t.SwitchCase>> | Array<Matcher<t.SwitchCase>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.SwitchStatement {
+    if (
+      !isNode(node) ||
+      !t.isSwitchStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.discriminant === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.discriminant.match(node.discriminant)) {
+      return false;
+    }
+
+    if (typeof this.cases === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.cases)) {
+      if (!tupleOf<unknown>(...this.cases).match(node.cases)) {
+        return false;
+      }
+    } else if (!this.cases.match(node.cases)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function switchStatement(
+  discriminant?: Matcher<t.Expression>,
+  cases?: Matcher<Array<t.SwitchCase>> | Array<Matcher<t.SwitchCase>>,
+): Matcher<t.SwitchStatement> {
+  return new SwitchStatementMatcher(
+    discriminant,
+    cases,
+  );
+}
+
+export class ThisExpressionMatcher extends Matcher<t.ThisExpression> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ThisExpression {
+    if (
+      !isNode(node) ||
+      !t.isThisExpression(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function thisExpression(
+): Matcher<t.ThisExpression> {
+  return new ThisExpressionMatcher(
+  );
+}
+
+export class ThrowStatementMatcher extends Matcher<t.ThrowStatement> {
+  constructor(
+    private readonly argument?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ThrowStatement {
+    if (
+      !isNode(node) ||
+      !t.isThrowStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function throwStatement(
+  argument?: Matcher<t.Expression>,
+): Matcher<t.ThrowStatement> {
+  return new ThrowStatementMatcher(
+    argument,
+  );
+}
+
+export class TryStatementMatcher extends Matcher<t.TryStatement> {
+  constructor(
+    private readonly block?: Matcher<t.BlockStatement>,
+    private readonly handler?: Matcher<t.CatchClause> | null,
+    private readonly finalizer?: Matcher<t.BlockStatement> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TryStatement {
+    if (
+      !isNode(node) ||
+      !t.isTryStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.block === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.block.match(node.block)) {
+      return false;
+    }
+
+    if (typeof this.handler === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.handler === null) {
+      // null matcher means we expect null value
+      if (node.handler !== null) {
+        return false;
+      }
+    } else if (node.handler === null) {
+      return false;
+    } else if (!this.handler.match(node.handler)) {
+      return false;
+    }
+
+    if (typeof this.finalizer === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.finalizer === null) {
+      // null matcher means we expect null value
+      if (node.finalizer !== null) {
+        return false;
+      }
+    } else if (node.finalizer === null) {
+      return false;
+    } else if (!this.finalizer.match(node.finalizer)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tryStatement(
+  block?: Matcher<t.BlockStatement>,
+  handler?: Matcher<t.CatchClause> | null,
+  finalizer?: Matcher<t.BlockStatement> | null,
+): Matcher<t.TryStatement> {
+  return new TryStatementMatcher(
+    block,
+    handler,
+    finalizer,
+  );
+}
+
+export class UnaryExpressionMatcher extends Matcher<t.UnaryExpression> {
+  constructor(
+    private readonly operator?: Matcher<"void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof"> | string,
+    private readonly argument?: Matcher<t.Expression>,
+    private readonly prefix?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.UnaryExpression {
+    if (
+      !isNode(node) ||
+      !t.isUnaryExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.operator === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.operator === 'string') {
+      if (this.operator !== node.operator) {
+        return false;
+      }
+    } else if (!this.operator.match(node.operator)) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    if (typeof this.prefix === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.prefix === 'boolean') {
+      if (this.prefix !== node.prefix) {
+        return false;
+      }
+    } else if (!this.prefix.match(node.prefix)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function unaryExpression(
+  operator?: Matcher<"void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof"> | string,
+  argument?: Matcher<t.Expression>,
+  prefix?: Matcher<boolean> | boolean,
+): Matcher<t.UnaryExpression> {
+  return new UnaryExpressionMatcher(
+    operator,
+    argument,
+    prefix,
+  );
+}
+
+export class UpdateExpressionMatcher extends Matcher<t.UpdateExpression> {
+  constructor(
+    private readonly operator?: Matcher<"++" | "--"> | string,
+    private readonly argument?: Matcher<t.Expression>,
+    private readonly prefix?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.UpdateExpression {
+    if (
+      !isNode(node) ||
+      !t.isUpdateExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.operator === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.operator === 'string') {
+      if (this.operator !== node.operator) {
+        return false;
+      }
+    } else if (!this.operator.match(node.operator)) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    if (typeof this.prefix === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.prefix === 'boolean') {
+      if (this.prefix !== node.prefix) {
+        return false;
+      }
+    } else if (!this.prefix.match(node.prefix)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function updateExpression(
+  operator?: Matcher<"++" | "--"> | string,
+  argument?: Matcher<t.Expression>,
+  prefix?: Matcher<boolean> | boolean,
+): Matcher<t.UpdateExpression> {
+  return new UpdateExpressionMatcher(
+    operator,
+    argument,
+    prefix,
+  );
+}
+
+export class VariableDeclarationMatcher extends Matcher<t.VariableDeclaration> {
+  constructor(
+    private readonly kind?: Matcher<"var" | "let" | "const"> | string,
+    private readonly declarations?: Matcher<Array<t.VariableDeclarator>> | Array<Matcher<t.VariableDeclarator>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.VariableDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isVariableDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.kind === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.kind === 'string') {
+      if (this.kind !== node.kind) {
+        return false;
+      }
+    } else if (!this.kind.match(node.kind)) {
+      return false;
+    }
+
+    if (typeof this.declarations === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.declarations)) {
+      if (!tupleOf<unknown>(...this.declarations).match(node.declarations)) {
+        return false;
+      }
+    } else if (!this.declarations.match(node.declarations)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function variableDeclaration(
+  kind?: Matcher<"var" | "let" | "const"> | string,
+  declarations?: Matcher<Array<t.VariableDeclarator>> | Array<Matcher<t.VariableDeclarator>>,
+): Matcher<t.VariableDeclaration> {
+  return new VariableDeclarationMatcher(
+    kind,
+    declarations,
+  );
+}
+
+export class VariableDeclaratorMatcher extends Matcher<t.VariableDeclarator> {
+  constructor(
+    private readonly id?: Matcher<t.LVal>,
+    private readonly init?: Matcher<t.Expression> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.VariableDeclarator {
+    if (
+      !isNode(node) ||
+      !t.isVariableDeclarator(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.init === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.init === null) {
+      // null matcher means we expect null value
+      if (node.init !== null) {
+        return false;
+      }
+    } else if (node.init === null) {
+      return false;
+    } else if (!this.init.match(node.init)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function variableDeclarator(
+  id?: Matcher<t.LVal>,
+  init?: Matcher<t.Expression> | null,
+): Matcher<t.VariableDeclarator> {
+  return new VariableDeclaratorMatcher(
+    id,
+    init,
+  );
+}
+
+export class WhileStatementMatcher extends Matcher<t.WhileStatement> {
+  constructor(
+    private readonly test?: Matcher<t.Expression>,
+    private readonly body?: Matcher<t.BlockStatement | t.Statement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.WhileStatement {
+    if (
+      !isNode(node) ||
+      !t.isWhileStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.test === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.test.match(node.test)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function whileStatement(
+  test?: Matcher<t.Expression>,
+  body?: Matcher<t.BlockStatement | t.Statement>,
+): Matcher<t.WhileStatement> {
+  return new WhileStatementMatcher(
+    test,
+    body,
+  );
+}
+
+export class WithStatementMatcher extends Matcher<t.WithStatement> {
+  constructor(
+    private readonly object?: Matcher<t.Expression>,
+    private readonly body?: Matcher<t.BlockStatement | t.Statement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.WithStatement {
+    if (
+      !isNode(node) ||
+      !t.isWithStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.object === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.object.match(node.object)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function withStatement(
+  object?: Matcher<t.Expression>,
+  body?: Matcher<t.BlockStatement | t.Statement>,
+): Matcher<t.WithStatement> {
+  return new WithStatementMatcher(
+    object,
+    body,
+  );
+}
+
+export class AssignmentPatternMatcher extends Matcher<t.AssignmentPattern> {
+  constructor(
+    private readonly left?: Matcher<t.Identifier | t.ObjectPattern | t.ArrayPattern>,
+    private readonly right?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.AssignmentPattern {
+    if (
+      !isNode(node) ||
+      !t.isAssignmentPattern(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.left === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.left.match(node.left)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function assignmentPattern(
+  left?: Matcher<t.Identifier | t.ObjectPattern | t.ArrayPattern>,
+  right?: Matcher<t.Expression>,
+): Matcher<t.AssignmentPattern> {
+  return new AssignmentPatternMatcher(
+    left,
+    right,
+  );
+}
+
+export class ArrayPatternMatcher extends Matcher<t.ArrayPattern> {
+  constructor(
+    private readonly elements?: Matcher<Array<t.PatternLike>> | Array<Matcher<t.PatternLike>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ArrayPattern {
+    if (
+      !isNode(node) ||
+      !t.isArrayPattern(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.elements === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.elements)) {
+      if (!tupleOf<unknown>(...this.elements).match(node.elements)) {
+        return false;
+      }
+    } else if (!this.elements.match(node.elements)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function arrayPattern(
+  elements?: Matcher<Array<t.PatternLike>> | Array<Matcher<t.PatternLike>>,
+): Matcher<t.ArrayPattern> {
+  return new ArrayPatternMatcher(
+    elements,
+  );
+}
+
+export class ArrowFunctionExpressionMatcher extends Matcher<t.ArrowFunctionExpression> {
+  constructor(
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly body?: Matcher<t.BlockStatement | t.Expression>,
+    private readonly async?: Matcher<boolean> | boolean | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ArrowFunctionExpression {
+    if (
+      !isNode(node) ||
+      !t.isArrowFunctionExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.async === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.async === 'boolean') {
+      if (this.async !== node.async) {
+        return false;
+      }
+    } else if (this.async === null) {
+      // null matcher means we expect null value
+      if (node.async !== null) {
+        return false;
+      }
+    } else if (node.async === null) {
+      return false;
+    } else if (!this.async.match(node.async)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function arrowFunctionExpression(
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  body?: Matcher<t.BlockStatement | t.Expression>,
+  async?: Matcher<boolean> | boolean | null,
+): Matcher<t.ArrowFunctionExpression> {
+  return new ArrowFunctionExpressionMatcher(
+    params,
+    body,
+    async,
+  );
+}
+
+export class ClassBodyMatcher extends Matcher<t.ClassBody> {
+  constructor(
+    private readonly body?: Matcher<Array<t.ClassMethod | t.ClassPrivateMethod | t.ClassProperty | t.ClassPrivateProperty | t.TSDeclareMethod | t.TSIndexSignature>> | Array<Matcher<t.ClassMethod> | Matcher<t.ClassPrivateMethod> | Matcher<t.ClassProperty> | Matcher<t.ClassPrivateProperty> | Matcher<t.TSDeclareMethod> | Matcher<t.TSIndexSignature>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ClassBody {
+    if (
+      !isNode(node) ||
+      !t.isClassBody(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.body)) {
+      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+        return false;
+      }
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function classBody(
+  body?: Matcher<Array<t.ClassMethod | t.ClassPrivateMethod | t.ClassProperty | t.ClassPrivateProperty | t.TSDeclareMethod | t.TSIndexSignature>> | Array<Matcher<t.ClassMethod> | Matcher<t.ClassPrivateMethod> | Matcher<t.ClassProperty> | Matcher<t.ClassPrivateProperty> | Matcher<t.TSDeclareMethod> | Matcher<t.TSIndexSignature>>,
+): Matcher<t.ClassBody> {
+  return new ClassBodyMatcher(
+    body,
+  );
+}
+
+export class ClassDeclarationMatcher extends Matcher<t.ClassDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier> | null,
+    private readonly superClass?: Matcher<t.Expression> | null,
+    private readonly body?: Matcher<t.ClassBody>,
+    private readonly decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ClassDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isClassDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.id === null) {
+      // null matcher means we expect null value
+      if (node.id !== null) {
+        return false;
+      }
+    } else if (node.id === null) {
+      return false;
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.superClass === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.superClass === null) {
+      // null matcher means we expect null value
+      if (node.superClass !== null) {
+        return false;
+      }
+    } else if (node.superClass === null) {
+      return false;
+    } else if (!this.superClass.match(node.superClass)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.decorators === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.decorators === null) {
+      // null matcher means we expect null value
+      if (node.decorators !== null) {
+        return false;
+      }
+    } else if (node.decorators === null) {
+      return false;
+    } else if (Array.isArray(this.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+        return false;
+      }
+    } else if (!this.decorators.match(node.decorators)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function classDeclaration(
+  id?: Matcher<t.Identifier> | null,
+  superClass?: Matcher<t.Expression> | null,
+  body?: Matcher<t.ClassBody>,
+  decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+): Matcher<t.ClassDeclaration> {
+  return new ClassDeclarationMatcher(
+    id,
+    superClass,
+    body,
+    decorators,
+  );
+}
+
+export class ClassExpressionMatcher extends Matcher<t.ClassExpression> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier> | null,
+    private readonly superClass?: Matcher<t.Expression> | null,
+    private readonly body?: Matcher<t.ClassBody>,
+    private readonly decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ClassExpression {
+    if (
+      !isNode(node) ||
+      !t.isClassExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.id === null) {
+      // null matcher means we expect null value
+      if (node.id !== null) {
+        return false;
+      }
+    } else if (node.id === null) {
+      return false;
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.superClass === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.superClass === null) {
+      // null matcher means we expect null value
+      if (node.superClass !== null) {
+        return false;
+      }
+    } else if (node.superClass === null) {
+      return false;
+    } else if (!this.superClass.match(node.superClass)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.decorators === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.decorators === null) {
+      // null matcher means we expect null value
+      if (node.decorators !== null) {
+        return false;
+      }
+    } else if (node.decorators === null) {
+      return false;
+    } else if (Array.isArray(this.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+        return false;
+      }
+    } else if (!this.decorators.match(node.decorators)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function classExpression(
+  id?: Matcher<t.Identifier> | null,
+  superClass?: Matcher<t.Expression> | null,
+  body?: Matcher<t.ClassBody>,
+  decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+): Matcher<t.ClassExpression> {
+  return new ClassExpressionMatcher(
+    id,
+    superClass,
+    body,
+    decorators,
+  );
+}
+
+export class ExportAllDeclarationMatcher extends Matcher<t.ExportAllDeclaration> {
+  constructor(
+    private readonly source?: Matcher<t.StringLiteral>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ExportAllDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isExportAllDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.source === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.source.match(node.source)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function exportAllDeclaration(
+  source?: Matcher<t.StringLiteral>,
+): Matcher<t.ExportAllDeclaration> {
+  return new ExportAllDeclarationMatcher(
+    source,
+  );
+}
+
+export class ExportDefaultDeclarationMatcher extends Matcher<t.ExportDefaultDeclaration> {
+  constructor(
+    private readonly declaration?: Matcher<t.FunctionDeclaration | t.TSDeclareFunction | t.ClassDeclaration | t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ExportDefaultDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isExportDefaultDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.declaration === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.declaration.match(node.declaration)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function exportDefaultDeclaration(
+  declaration?: Matcher<t.FunctionDeclaration | t.TSDeclareFunction | t.ClassDeclaration | t.Expression>,
+): Matcher<t.ExportDefaultDeclaration> {
+  return new ExportDefaultDeclarationMatcher(
+    declaration,
+  );
+}
+
+export class ExportNamedDeclarationMatcher extends Matcher<t.ExportNamedDeclaration> {
+  constructor(
+    private readonly declaration?: Matcher<t.Declaration> | null,
+    private readonly specifiers?: Matcher<Array<t.ExportSpecifier | t.ExportDefaultSpecifier | t.ExportNamespaceSpecifier>> | Array<Matcher<t.ExportSpecifier> | Matcher<t.ExportDefaultSpecifier> | Matcher<t.ExportNamespaceSpecifier>>,
+    private readonly source?: Matcher<t.StringLiteral> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ExportNamedDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isExportNamedDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.declaration === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.declaration === null) {
+      // null matcher means we expect null value
+      if (node.declaration !== null) {
+        return false;
+      }
+    } else if (node.declaration === null) {
+      return false;
+    } else if (!this.declaration.match(node.declaration)) {
+      return false;
+    }
+
+    if (typeof this.specifiers === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.specifiers)) {
+      if (!tupleOf<unknown>(...this.specifiers).match(node.specifiers)) {
+        return false;
+      }
+    } else if (!this.specifiers.match(node.specifiers)) {
+      return false;
+    }
+
+    if (typeof this.source === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.source === null) {
+      // null matcher means we expect null value
+      if (node.source !== null) {
+        return false;
+      }
+    } else if (node.source === null) {
+      return false;
+    } else if (!this.source.match(node.source)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function exportNamedDeclaration(
+  declaration?: Matcher<t.Declaration> | null,
+  specifiers?: Matcher<Array<t.ExportSpecifier | t.ExportDefaultSpecifier | t.ExportNamespaceSpecifier>> | Array<Matcher<t.ExportSpecifier> | Matcher<t.ExportDefaultSpecifier> | Matcher<t.ExportNamespaceSpecifier>>,
+  source?: Matcher<t.StringLiteral> | null,
+): Matcher<t.ExportNamedDeclaration> {
+  return new ExportNamedDeclarationMatcher(
+    declaration,
+    specifiers,
+    source,
+  );
+}
+
+export class ExportSpecifierMatcher extends Matcher<t.ExportSpecifier> {
+  constructor(
+    private readonly local?: Matcher<t.Identifier>,
+    private readonly exported?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ExportSpecifier {
+    if (
+      !isNode(node) ||
+      !t.isExportSpecifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.local === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.local.match(node.local)) {
+      return false;
+    }
+
+    if (typeof this.exported === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.exported.match(node.exported)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function exportSpecifier(
+  local?: Matcher<t.Identifier>,
+  exported?: Matcher<t.Identifier>,
+): Matcher<t.ExportSpecifier> {
+  return new ExportSpecifierMatcher(
+    local,
+    exported,
+  );
+}
+
+export class ForOfStatementMatcher extends Matcher<t.ForOfStatement> {
+  constructor(
+    private readonly left?: Matcher<t.VariableDeclaration | t.LVal>,
+    private readonly right?: Matcher<t.Expression>,
+    private readonly body?: Matcher<t.Statement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ForOfStatement {
+    if (
+      !isNode(node) ||
+      !t.isForOfStatement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.left === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.left.match(node.left)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function forOfStatement(
+  left?: Matcher<t.VariableDeclaration | t.LVal>,
+  right?: Matcher<t.Expression>,
+  body?: Matcher<t.Statement>,
+): Matcher<t.ForOfStatement> {
+  return new ForOfStatementMatcher(
+    left,
+    right,
+    body,
+  );
+}
+
+export class ImportDeclarationMatcher extends Matcher<t.ImportDeclaration> {
+  constructor(
+    private readonly specifiers?: Matcher<Array<t.ImportSpecifier | t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier>> | Array<Matcher<t.ImportSpecifier> | Matcher<t.ImportDefaultSpecifier> | Matcher<t.ImportNamespaceSpecifier>>,
+    private readonly source?: Matcher<t.StringLiteral>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ImportDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isImportDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.specifiers === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.specifiers)) {
+      if (!tupleOf<unknown>(...this.specifiers).match(node.specifiers)) {
+        return false;
+      }
+    } else if (!this.specifiers.match(node.specifiers)) {
+      return false;
+    }
+
+    if (typeof this.source === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.source.match(node.source)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function importDeclaration(
+  specifiers?: Matcher<Array<t.ImportSpecifier | t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier>> | Array<Matcher<t.ImportSpecifier> | Matcher<t.ImportDefaultSpecifier> | Matcher<t.ImportNamespaceSpecifier>>,
+  source?: Matcher<t.StringLiteral>,
+): Matcher<t.ImportDeclaration> {
+  return new ImportDeclarationMatcher(
+    specifiers,
+    source,
+  );
+}
+
+export class ImportDefaultSpecifierMatcher extends Matcher<t.ImportDefaultSpecifier> {
+  constructor(
+    private readonly local?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ImportDefaultSpecifier {
+    if (
+      !isNode(node) ||
+      !t.isImportDefaultSpecifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.local === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.local.match(node.local)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function importDefaultSpecifier(
+  local?: Matcher<t.Identifier>,
+): Matcher<t.ImportDefaultSpecifier> {
+  return new ImportDefaultSpecifierMatcher(
+    local,
+  );
+}
+
+export class ImportNamespaceSpecifierMatcher extends Matcher<t.ImportNamespaceSpecifier> {
+  constructor(
+    private readonly local?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ImportNamespaceSpecifier {
+    if (
+      !isNode(node) ||
+      !t.isImportNamespaceSpecifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.local === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.local.match(node.local)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function importNamespaceSpecifier(
+  local?: Matcher<t.Identifier>,
+): Matcher<t.ImportNamespaceSpecifier> {
+  return new ImportNamespaceSpecifierMatcher(
+    local,
+  );
+}
+
+export class ImportSpecifierMatcher extends Matcher<t.ImportSpecifier> {
+  constructor(
+    private readonly local?: Matcher<t.Identifier>,
+    private readonly imported?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ImportSpecifier {
+    if (
+      !isNode(node) ||
+      !t.isImportSpecifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.local === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.local.match(node.local)) {
+      return false;
+    }
+
+    if (typeof this.imported === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.imported.match(node.imported)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function importSpecifier(
+  local?: Matcher<t.Identifier>,
+  imported?: Matcher<t.Identifier>,
+): Matcher<t.ImportSpecifier> {
+  return new ImportSpecifierMatcher(
+    local,
+    imported,
+  );
+}
+
+export class MetaPropertyMatcher extends Matcher<t.MetaProperty> {
+  constructor(
+    private readonly meta?: Matcher<t.Identifier>,
+    private readonly property?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.MetaProperty {
+    if (
+      !isNode(node) ||
+      !t.isMetaProperty(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.meta === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.meta.match(node.meta)) {
+      return false;
+    }
+
+    if (typeof this.property === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.property.match(node.property)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function metaProperty(
+  meta?: Matcher<t.Identifier>,
+  property?: Matcher<t.Identifier>,
+): Matcher<t.MetaProperty> {
+  return new MetaPropertyMatcher(
+    meta,
+    property,
+  );
+}
+
+export class ClassMethodMatcher extends Matcher<t.ClassMethod> {
+  constructor(
+    private readonly kind?: Matcher<"get" | "set" | "method" | "constructor"> | string | null,
+    private readonly key?: Matcher<t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression>,
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly body?: Matcher<t.BlockStatement>,
+    private readonly computed?: Matcher<boolean> | boolean | null,
+    private readonly _static?: Matcher<boolean> | boolean | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ClassMethod {
+    if (
+      !isNode(node) ||
+      !t.isClassMethod(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.kind === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.kind === 'string') {
+      if (this.kind !== node.kind) {
+        return false;
+      }
+    } else if (this.kind === null) {
+      // null matcher means we expect null value
+      if (node.kind !== null) {
+        return false;
+      }
+    } else if (node.kind === null) {
+      return false;
+    } else if (!this.kind.match(node.kind)) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.computed === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.computed === 'boolean') {
+      if (this.computed !== node.computed) {
+        return false;
+      }
+    } else if (this.computed === null) {
+      // null matcher means we expect null value
+      if (node.computed !== null) {
+        return false;
+      }
+    } else if (node.computed === null) {
+      return false;
+    } else if (!this.computed.match(node.computed)) {
+      return false;
+    }
+
+    if (typeof this._static === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this._static === 'boolean') {
+      if (this._static !== node.static) {
+        return false;
+      }
+    } else if (this._static === null) {
+      // null matcher means we expect null value
+      if (node.static !== null) {
+        return false;
+      }
+    } else if (node.static === null) {
+      return false;
+    } else if (!this._static.match(node.static)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function classMethod(
+  kind?: Matcher<"get" | "set" | "method" | "constructor"> | string | null,
+  key?: Matcher<t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression>,
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  body?: Matcher<t.BlockStatement>,
+  computed?: Matcher<boolean> | boolean | null,
+  _static?: Matcher<boolean> | boolean | null,
+): Matcher<t.ClassMethod> {
+  return new ClassMethodMatcher(
+    kind,
+    key,
+    params,
+    body,
+    computed,
+    _static,
+  );
+}
+
+export class ObjectPatternMatcher extends Matcher<t.ObjectPattern> {
+  constructor(
+    private readonly properties?: Matcher<Array<t.RestElement | t.ObjectProperty>> | Array<Matcher<t.RestElement> | Matcher<t.ObjectProperty>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectPattern {
+    if (
+      !isNode(node) ||
+      !t.isObjectPattern(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.properties === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.properties)) {
+      if (!tupleOf<unknown>(...this.properties).match(node.properties)) {
+        return false;
+      }
+    } else if (!this.properties.match(node.properties)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectPattern(
+  properties?: Matcher<Array<t.RestElement | t.ObjectProperty>> | Array<Matcher<t.RestElement> | Matcher<t.ObjectProperty>>,
+): Matcher<t.ObjectPattern> {
+  return new ObjectPatternMatcher(
+    properties,
+  );
+}
+
+export class SpreadElementMatcher extends Matcher<t.SpreadElement> {
+  constructor(
+    private readonly argument?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.SpreadElement {
+    if (
+      !isNode(node) ||
+      !t.isSpreadElement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function spreadElement(
+  argument?: Matcher<t.Expression>,
+): Matcher<t.SpreadElement> {
+  return new SpreadElementMatcher(
+    argument,
+  );
+}
+
+export class SuperMatcher extends Matcher<t.Super> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.Super {
+    if (
+      !isNode(node) ||
+      !t.isSuper(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function Super(
+): Matcher<t.Super> {
+  return new SuperMatcher(
+  );
+}
+
+export class TaggedTemplateExpressionMatcher extends Matcher<t.TaggedTemplateExpression> {
+  constructor(
+    private readonly tag?: Matcher<t.Expression>,
+    private readonly quasi?: Matcher<t.TemplateLiteral>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TaggedTemplateExpression {
+    if (
+      !isNode(node) ||
+      !t.isTaggedTemplateExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.tag === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.tag.match(node.tag)) {
+      return false;
+    }
+
+    if (typeof this.quasi === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.quasi.match(node.quasi)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function taggedTemplateExpression(
+  tag?: Matcher<t.Expression>,
+  quasi?: Matcher<t.TemplateLiteral>,
+): Matcher<t.TaggedTemplateExpression> {
+  return new TaggedTemplateExpressionMatcher(
+    tag,
+    quasi,
+  );
+}
+
+export class TemplateElementMatcher extends Matcher<t.TemplateElement> {
+  constructor(
+    private readonly value?: Matcher<any>,
+    private readonly tail?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TemplateElement {
+    if (
+      !isNode(node) ||
+      !t.isTemplateElement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    if (typeof this.tail === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.tail === 'boolean') {
+      if (this.tail !== node.tail) {
+        return false;
+      }
+    } else if (!this.tail.match(node.tail)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function templateElement(
+  value?: Matcher<any>,
+  tail?: Matcher<boolean> | boolean,
+): Matcher<t.TemplateElement> {
+  return new TemplateElementMatcher(
+    value,
+    tail,
+  );
+}
+
+export class TemplateLiteralMatcher extends Matcher<t.TemplateLiteral> {
+  constructor(
+    private readonly quasis?: Matcher<Array<t.TemplateElement>> | Array<Matcher<t.TemplateElement>>,
+    private readonly expressions?: Matcher<Array<t.Expression>> | Array<Matcher<t.Expression>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TemplateLiteral {
+    if (
+      !isNode(node) ||
+      !t.isTemplateLiteral(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.quasis === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.quasis)) {
+      if (!tupleOf<unknown>(...this.quasis).match(node.quasis)) {
+        return false;
+      }
+    } else if (!this.quasis.match(node.quasis)) {
+      return false;
+    }
+
+    if (typeof this.expressions === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.expressions)) {
+      if (!tupleOf<unknown>(...this.expressions).match(node.expressions)) {
+        return false;
+      }
+    } else if (!this.expressions.match(node.expressions)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function templateLiteral(
+  quasis?: Matcher<Array<t.TemplateElement>> | Array<Matcher<t.TemplateElement>>,
+  expressions?: Matcher<Array<t.Expression>> | Array<Matcher<t.Expression>>,
+): Matcher<t.TemplateLiteral> {
+  return new TemplateLiteralMatcher(
+    quasis,
+    expressions,
+  );
+}
+
+export class YieldExpressionMatcher extends Matcher<t.YieldExpression> {
+  constructor(
+    private readonly argument?: Matcher<t.Expression> | null,
+    private readonly delegate?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.YieldExpression {
+    if (
+      !isNode(node) ||
+      !t.isYieldExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.argument === null) {
+      // null matcher means we expect null value
+      if (node.argument !== null) {
+        return false;
+      }
+    } else if (node.argument === null) {
+      return false;
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    if (typeof this.delegate === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.delegate === 'boolean') {
+      if (this.delegate !== node.delegate) {
+        return false;
+      }
+    } else if (!this.delegate.match(node.delegate)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function yieldExpression(
+  argument?: Matcher<t.Expression> | null,
+  delegate?: Matcher<boolean> | boolean,
+): Matcher<t.YieldExpression> {
+  return new YieldExpressionMatcher(
+    argument,
+    delegate,
+  );
+}
+
+export class AnyTypeAnnotationMatcher extends Matcher<t.AnyTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.AnyTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isAnyTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function anyTypeAnnotation(
+): Matcher<t.AnyTypeAnnotation> {
+  return new AnyTypeAnnotationMatcher(
+  );
+}
+
+export class ArrayTypeAnnotationMatcher extends Matcher<t.ArrayTypeAnnotation> {
+  constructor(
+    private readonly elementType?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ArrayTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isArrayTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.elementType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.elementType.match(node.elementType)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function arrayTypeAnnotation(
+  elementType?: Matcher<t.FlowType>,
+): Matcher<t.ArrayTypeAnnotation> {
+  return new ArrayTypeAnnotationMatcher(
+    elementType,
+  );
+}
+
+export class BooleanTypeAnnotationMatcher extends Matcher<t.BooleanTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.BooleanTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isBooleanTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function booleanTypeAnnotation(
+): Matcher<t.BooleanTypeAnnotation> {
+  return new BooleanTypeAnnotationMatcher(
+  );
+}
+
+export class BooleanLiteralTypeAnnotationMatcher extends Matcher<t.BooleanLiteralTypeAnnotation> {
+  constructor(
+    private readonly value?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.BooleanLiteralTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isBooleanLiteralTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'boolean') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function booleanLiteralTypeAnnotation(
+  value?: Matcher<boolean> | boolean,
+): Matcher<t.BooleanLiteralTypeAnnotation> {
+  return new BooleanLiteralTypeAnnotationMatcher(
+    value,
+  );
+}
+
+export class NullLiteralTypeAnnotationMatcher extends Matcher<t.NullLiteralTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.NullLiteralTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isNullLiteralTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function nullLiteralTypeAnnotation(
+): Matcher<t.NullLiteralTypeAnnotation> {
+  return new NullLiteralTypeAnnotationMatcher(
+  );
+}
+
+export class ClassImplementsMatcher extends Matcher<t.ClassImplements> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterInstantiation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ClassImplements {
+    if (
+      !isNode(node) ||
+      !t.isClassImplements(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function classImplements(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterInstantiation> | null,
+): Matcher<t.ClassImplements> {
+  return new ClassImplementsMatcher(
+    id,
+    typeParameters,
+  );
+}
+
+export class DeclareClassMatcher extends Matcher<t.DeclareClass> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterInstantiation> | null,
+    private readonly _extends?: Matcher<Array<t.InterfaceExtends>> | Array<Matcher<t.InterfaceExtends>> | null,
+    private readonly body?: Matcher<t.ObjectTypeAnnotation>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareClass {
+    if (
+      !isNode(node) ||
+      !t.isDeclareClass(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this._extends === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this._extends === null) {
+      // null matcher means we expect null value
+      if (node.extends !== null) {
+        return false;
+      }
+    } else if (node.extends === null) {
+      return false;
+    } else if (Array.isArray(this._extends)) {
+      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+        return false;
+      }
+    } else if (!this._extends.match(node.extends)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareClass(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterInstantiation> | null,
+  _extends?: Matcher<Array<t.InterfaceExtends>> | Array<Matcher<t.InterfaceExtends>> | null,
+  body?: Matcher<t.ObjectTypeAnnotation>,
+): Matcher<t.DeclareClass> {
+  return new DeclareClassMatcher(
+    id,
+    typeParameters,
+    _extends,
+    body,
+  );
+}
+
+export class DeclareFunctionMatcher extends Matcher<t.DeclareFunction> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareFunction {
+    if (
+      !isNode(node) ||
+      !t.isDeclareFunction(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareFunction(
+  id?: Matcher<t.Identifier>,
+): Matcher<t.DeclareFunction> {
+  return new DeclareFunctionMatcher(
+    id,
+  );
+}
+
+export class DeclareInterfaceMatcher extends Matcher<t.DeclareInterface> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+    private readonly _extends?: Matcher<Array<t.InterfaceExtends>> | Array<Matcher<t.InterfaceExtends>> | null,
+    private readonly body?: Matcher<t.ObjectTypeAnnotation>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareInterface {
+    if (
+      !isNode(node) ||
+      !t.isDeclareInterface(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this._extends === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this._extends === null) {
+      // null matcher means we expect null value
+      if (node.extends !== null) {
+        return false;
+      }
+    } else if (node.extends === null) {
+      return false;
+    } else if (Array.isArray(this._extends)) {
+      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+        return false;
+      }
+    } else if (!this._extends.match(node.extends)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareInterface(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+  _extends?: Matcher<Array<t.InterfaceExtends>> | Array<Matcher<t.InterfaceExtends>> | null,
+  body?: Matcher<t.ObjectTypeAnnotation>,
+): Matcher<t.DeclareInterface> {
+  return new DeclareInterfaceMatcher(
+    id,
+    typeParameters,
+    _extends,
+    body,
+  );
+}
+
+export class DeclareModuleMatcher extends Matcher<t.DeclareModule> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier | t.StringLiteral>,
+    private readonly body?: Matcher<t.BlockStatement>,
+    private readonly kind?: Matcher<"CommonJS" | "ES"> | string | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareModule {
+    if (
+      !isNode(node) ||
+      !t.isDeclareModule(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this.kind === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.kind === 'string') {
+      if (this.kind !== node.kind) {
+        return false;
+      }
+    } else if (this.kind === null) {
+      // null matcher means we expect null value
+      if (node.kind !== null) {
+        return false;
+      }
+    } else if (node.kind === null) {
+      return false;
+    } else if (!this.kind.match(node.kind)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareModule(
+  id?: Matcher<t.Identifier | t.StringLiteral>,
+  body?: Matcher<t.BlockStatement>,
+  kind?: Matcher<"CommonJS" | "ES"> | string | null,
+): Matcher<t.DeclareModule> {
+  return new DeclareModuleMatcher(
+    id,
+    body,
+    kind,
+  );
+}
+
+export class DeclareModuleExportsMatcher extends Matcher<t.DeclareModuleExports> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.TypeAnnotation>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareModuleExports {
+    if (
+      !isNode(node) ||
+      !t.isDeclareModuleExports(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareModuleExports(
+  typeAnnotation?: Matcher<t.TypeAnnotation>,
+): Matcher<t.DeclareModuleExports> {
+  return new DeclareModuleExportsMatcher(
+    typeAnnotation,
+  );
+}
+
+export class DeclareTypeAliasMatcher extends Matcher<t.DeclareTypeAlias> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+    private readonly right?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareTypeAlias {
+    if (
+      !isNode(node) ||
+      !t.isDeclareTypeAlias(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareTypeAlias(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+  right?: Matcher<t.FlowType>,
+): Matcher<t.DeclareTypeAlias> {
+  return new DeclareTypeAliasMatcher(
+    id,
+    typeParameters,
+    right,
+  );
+}
+
+export class DeclareOpaqueTypeMatcher extends Matcher<t.DeclareOpaqueType> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+    private readonly supertype?: Matcher<t.FlowType> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareOpaqueType {
+    if (
+      !isNode(node) ||
+      !t.isDeclareOpaqueType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.supertype === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.supertype === null) {
+      // null matcher means we expect null value
+      if (node.supertype !== null) {
+        return false;
+      }
+    } else if (node.supertype === null) {
+      return false;
+    } else if (!this.supertype.match(node.supertype)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareOpaqueType(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+  supertype?: Matcher<t.FlowType> | null,
+): Matcher<t.DeclareOpaqueType> {
+  return new DeclareOpaqueTypeMatcher(
+    id,
+    typeParameters,
+    supertype,
+  );
+}
+
+export class DeclareVariableMatcher extends Matcher<t.DeclareVariable> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareVariable {
+    if (
+      !isNode(node) ||
+      !t.isDeclareVariable(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareVariable(
+  id?: Matcher<t.Identifier>,
+): Matcher<t.DeclareVariable> {
+  return new DeclareVariableMatcher(
+    id,
+  );
+}
+
+export class DeclareExportDeclarationMatcher extends Matcher<t.DeclareExportDeclaration> {
+  constructor(
+    private readonly declaration?: Matcher<t.Flow> | null,
+    private readonly specifiers?: Matcher<Array<t.ExportSpecifier | t.ExportNamespaceSpecifier>> | Array<Matcher<t.ExportSpecifier> | Matcher<t.ExportNamespaceSpecifier>> | null,
+    private readonly source?: Matcher<t.StringLiteral> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareExportDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isDeclareExportDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.declaration === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.declaration === null) {
+      // null matcher means we expect null value
+      if (node.declaration !== null) {
+        return false;
+      }
+    } else if (node.declaration === null) {
+      return false;
+    } else if (!this.declaration.match(node.declaration)) {
+      return false;
+    }
+
+    if (typeof this.specifiers === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.specifiers === null) {
+      // null matcher means we expect null value
+      if (node.specifiers !== null) {
+        return false;
+      }
+    } else if (node.specifiers === null) {
+      return false;
+    } else if (Array.isArray(this.specifiers)) {
+      if (!tupleOf<unknown>(...this.specifiers).match(node.specifiers)) {
+        return false;
+      }
+    } else if (!this.specifiers.match(node.specifiers)) {
+      return false;
+    }
+
+    if (typeof this.source === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.source === null) {
+      // null matcher means we expect null value
+      if (node.source !== null) {
+        return false;
+      }
+    } else if (node.source === null) {
+      return false;
+    } else if (!this.source.match(node.source)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareExportDeclaration(
+  declaration?: Matcher<t.Flow> | null,
+  specifiers?: Matcher<Array<t.ExportSpecifier | t.ExportNamespaceSpecifier>> | Array<Matcher<t.ExportSpecifier> | Matcher<t.ExportNamespaceSpecifier>> | null,
+  source?: Matcher<t.StringLiteral> | null,
+): Matcher<t.DeclareExportDeclaration> {
+  return new DeclareExportDeclarationMatcher(
+    declaration,
+    specifiers,
+    source,
+  );
+}
+
+export class DeclareExportAllDeclarationMatcher extends Matcher<t.DeclareExportAllDeclaration> {
+  constructor(
+    private readonly source?: Matcher<t.StringLiteral>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclareExportAllDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isDeclareExportAllDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.source === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.source.match(node.source)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declareExportAllDeclaration(
+  source?: Matcher<t.StringLiteral>,
+): Matcher<t.DeclareExportAllDeclaration> {
+  return new DeclareExportAllDeclarationMatcher(
+    source,
+  );
+}
+
+export class DeclaredPredicateMatcher extends Matcher<t.DeclaredPredicate> {
+  constructor(
+    private readonly value?: Matcher<t.Flow>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DeclaredPredicate {
+    if (
+      !isNode(node) ||
+      !t.isDeclaredPredicate(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function declaredPredicate(
+  value?: Matcher<t.Flow>,
+): Matcher<t.DeclaredPredicate> {
+  return new DeclaredPredicateMatcher(
+    value,
+  );
+}
+
+export class ExistsTypeAnnotationMatcher extends Matcher<t.ExistsTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ExistsTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isExistsTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function existsTypeAnnotation(
+): Matcher<t.ExistsTypeAnnotation> {
+  return new ExistsTypeAnnotationMatcher(
+  );
+}
+
+export class FunctionTypeAnnotationMatcher extends Matcher<t.FunctionTypeAnnotation> {
+  constructor(
+    private readonly typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+    private readonly params?: Matcher<Array<t.FunctionTypeParam>> | Array<Matcher<t.FunctionTypeParam>>,
+    private readonly rest?: Matcher<t.FunctionTypeParam> | null,
+    private readonly returnType?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.FunctionTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isFunctionTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.rest === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.rest === null) {
+      // null matcher means we expect null value
+      if (node.rest !== null) {
+        return false;
+      }
+    } else if (node.rest === null) {
+      return false;
+    } else if (!this.rest.match(node.rest)) {
+      return false;
+    }
+
+    if (typeof this.returnType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.returnType.match(node.returnType)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function functionTypeAnnotation(
+  typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+  params?: Matcher<Array<t.FunctionTypeParam>> | Array<Matcher<t.FunctionTypeParam>>,
+  rest?: Matcher<t.FunctionTypeParam> | null,
+  returnType?: Matcher<t.FlowType>,
+): Matcher<t.FunctionTypeAnnotation> {
+  return new FunctionTypeAnnotationMatcher(
+    typeParameters,
+    params,
+    rest,
+    returnType,
+  );
+}
+
+export class FunctionTypeParamMatcher extends Matcher<t.FunctionTypeParam> {
+  constructor(
+    private readonly name?: Matcher<t.Identifier> | null,
+    private readonly typeAnnotation?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.FunctionTypeParam {
+    if (
+      !isNode(node) ||
+      !t.isFunctionTypeParam(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.name === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.name === null) {
+      // null matcher means we expect null value
+      if (node.name !== null) {
+        return false;
+      }
+    } else if (node.name === null) {
+      return false;
+    } else if (!this.name.match(node.name)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function functionTypeParam(
+  name?: Matcher<t.Identifier> | null,
+  typeAnnotation?: Matcher<t.FlowType>,
+): Matcher<t.FunctionTypeParam> {
+  return new FunctionTypeParamMatcher(
+    name,
+    typeAnnotation,
+  );
+}
+
+export class GenericTypeAnnotationMatcher extends Matcher<t.GenericTypeAnnotation> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterInstantiation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.GenericTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isGenericTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function genericTypeAnnotation(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterInstantiation> | null,
+): Matcher<t.GenericTypeAnnotation> {
+  return new GenericTypeAnnotationMatcher(
+    id,
+    typeParameters,
+  );
+}
+
+export class InferredPredicateMatcher extends Matcher<t.InferredPredicate> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.InferredPredicate {
+    if (
+      !isNode(node) ||
+      !t.isInferredPredicate(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function inferredPredicate(
+): Matcher<t.InferredPredicate> {
+  return new InferredPredicateMatcher(
+  );
+}
+
+export class InterfaceExtendsMatcher extends Matcher<t.InterfaceExtends> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterInstantiation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.InterfaceExtends {
+    if (
+      !isNode(node) ||
+      !t.isInterfaceExtends(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function interfaceExtends(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterInstantiation> | null,
+): Matcher<t.InterfaceExtends> {
+  return new InterfaceExtendsMatcher(
+    id,
+    typeParameters,
+  );
+}
+
+export class InterfaceDeclarationMatcher extends Matcher<t.InterfaceDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+    private readonly _extends?: Matcher<Array<t.InterfaceExtends>> | Array<Matcher<t.InterfaceExtends>> | null,
+    private readonly body?: Matcher<t.ObjectTypeAnnotation>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.InterfaceDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isInterfaceDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this._extends === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this._extends === null) {
+      // null matcher means we expect null value
+      if (node.extends !== null) {
+        return false;
+      }
+    } else if (node.extends === null) {
+      return false;
+    } else if (Array.isArray(this._extends)) {
+      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+        return false;
+      }
+    } else if (!this._extends.match(node.extends)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function interfaceDeclaration(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+  _extends?: Matcher<Array<t.InterfaceExtends>> | Array<Matcher<t.InterfaceExtends>> | null,
+  body?: Matcher<t.ObjectTypeAnnotation>,
+): Matcher<t.InterfaceDeclaration> {
+  return new InterfaceDeclarationMatcher(
+    id,
+    typeParameters,
+    _extends,
+    body,
+  );
+}
+
+export class InterfaceTypeAnnotationMatcher extends Matcher<t.InterfaceTypeAnnotation> {
+  constructor(
+    private readonly _extends?: Matcher<Array<t.InterfaceExtends>> | Array<Matcher<t.InterfaceExtends>> | null,
+    private readonly body?: Matcher<t.ObjectTypeAnnotation>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.InterfaceTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isInterfaceTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this._extends === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this._extends === null) {
+      // null matcher means we expect null value
+      if (node.extends !== null) {
+        return false;
+      }
+    } else if (node.extends === null) {
+      return false;
+    } else if (Array.isArray(this._extends)) {
+      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+        return false;
+      }
+    } else if (!this._extends.match(node.extends)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function interfaceTypeAnnotation(
+  _extends?: Matcher<Array<t.InterfaceExtends>> | Array<Matcher<t.InterfaceExtends>> | null,
+  body?: Matcher<t.ObjectTypeAnnotation>,
+): Matcher<t.InterfaceTypeAnnotation> {
+  return new InterfaceTypeAnnotationMatcher(
+    _extends,
+    body,
+  );
+}
+
+export class IntersectionTypeAnnotationMatcher extends Matcher<t.IntersectionTypeAnnotation> {
+  constructor(
+    private readonly types?: Matcher<Array<t.FlowType>> | Array<Matcher<t.FlowType>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.IntersectionTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isIntersectionTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.types === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.types)) {
+      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+        return false;
+      }
+    } else if (!this.types.match(node.types)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function intersectionTypeAnnotation(
+  types?: Matcher<Array<t.FlowType>> | Array<Matcher<t.FlowType>>,
+): Matcher<t.IntersectionTypeAnnotation> {
+  return new IntersectionTypeAnnotationMatcher(
+    types,
+  );
+}
+
+export class MixedTypeAnnotationMatcher extends Matcher<t.MixedTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.MixedTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isMixedTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function mixedTypeAnnotation(
+): Matcher<t.MixedTypeAnnotation> {
+  return new MixedTypeAnnotationMatcher(
+  );
+}
+
+export class EmptyTypeAnnotationMatcher extends Matcher<t.EmptyTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.EmptyTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isEmptyTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function emptyTypeAnnotation(
+): Matcher<t.EmptyTypeAnnotation> {
+  return new EmptyTypeAnnotationMatcher(
+  );
+}
+
+export class NullableTypeAnnotationMatcher extends Matcher<t.NullableTypeAnnotation> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.NullableTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isNullableTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function nullableTypeAnnotation(
+  typeAnnotation?: Matcher<t.FlowType>,
+): Matcher<t.NullableTypeAnnotation> {
+  return new NullableTypeAnnotationMatcher(
+    typeAnnotation,
+  );
+}
+
+export class NumberLiteralTypeAnnotationMatcher extends Matcher<t.NumberLiteralTypeAnnotation> {
+  constructor(
+    private readonly value?: Matcher<number> | number,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.NumberLiteralTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isNumberLiteralTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'number') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function numberLiteralTypeAnnotation(
+  value?: Matcher<number> | number,
+): Matcher<t.NumberLiteralTypeAnnotation> {
+  return new NumberLiteralTypeAnnotationMatcher(
+    value,
+  );
+}
+
+export class NumberTypeAnnotationMatcher extends Matcher<t.NumberTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.NumberTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isNumberTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function numberTypeAnnotation(
+): Matcher<t.NumberTypeAnnotation> {
+  return new NumberTypeAnnotationMatcher(
+  );
+}
+
+export class ObjectTypeAnnotationMatcher extends Matcher<t.ObjectTypeAnnotation> {
+  constructor(
+    private readonly properties?: Matcher<Array<t.ObjectTypeProperty | t.ObjectTypeSpreadProperty>> | Array<Matcher<t.ObjectTypeProperty> | Matcher<t.ObjectTypeSpreadProperty>>,
+    private readonly indexers?: Matcher<Array<t.ObjectTypeIndexer>> | Array<Matcher<t.ObjectTypeIndexer>> | null,
+    private readonly callProperties?: Matcher<Array<t.ObjectTypeCallProperty>> | Array<Matcher<t.ObjectTypeCallProperty>> | null,
+    private readonly internalSlots?: Matcher<Array<t.ObjectTypeInternalSlot>> | Array<Matcher<t.ObjectTypeInternalSlot>> | null,
+    private readonly exact?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isObjectTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.properties === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.properties)) {
+      if (!tupleOf<unknown>(...this.properties).match(node.properties)) {
+        return false;
+      }
+    } else if (!this.properties.match(node.properties)) {
+      return false;
+    }
+
+    if (typeof this.indexers === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.indexers === null) {
+      // null matcher means we expect null value
+      if (node.indexers !== null) {
+        return false;
+      }
+    } else if (node.indexers === null) {
+      return false;
+    } else if (Array.isArray(this.indexers)) {
+      if (!tupleOf<unknown>(...this.indexers).match(node.indexers)) {
+        return false;
+      }
+    } else if (!this.indexers.match(node.indexers)) {
+      return false;
+    }
+
+    if (typeof this.callProperties === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.callProperties === null) {
+      // null matcher means we expect null value
+      if (node.callProperties !== null) {
+        return false;
+      }
+    } else if (node.callProperties === null) {
+      return false;
+    } else if (Array.isArray(this.callProperties)) {
+      if (!tupleOf<unknown>(...this.callProperties).match(node.callProperties)) {
+        return false;
+      }
+    } else if (!this.callProperties.match(node.callProperties)) {
+      return false;
+    }
+
+    if (typeof this.internalSlots === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.internalSlots === null) {
+      // null matcher means we expect null value
+      if (node.internalSlots !== null) {
+        return false;
+      }
+    } else if (node.internalSlots === null) {
+      return false;
+    } else if (Array.isArray(this.internalSlots)) {
+      if (!tupleOf<unknown>(...this.internalSlots).match(node.internalSlots)) {
+        return false;
+      }
+    } else if (!this.internalSlots.match(node.internalSlots)) {
+      return false;
+    }
+
+    if (typeof this.exact === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.exact === 'boolean') {
+      if (this.exact !== node.exact) {
+        return false;
+      }
+    } else if (!this.exact.match(node.exact)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectTypeAnnotation(
+  properties?: Matcher<Array<t.ObjectTypeProperty | t.ObjectTypeSpreadProperty>> | Array<Matcher<t.ObjectTypeProperty> | Matcher<t.ObjectTypeSpreadProperty>>,
+  indexers?: Matcher<Array<t.ObjectTypeIndexer>> | Array<Matcher<t.ObjectTypeIndexer>> | null,
+  callProperties?: Matcher<Array<t.ObjectTypeCallProperty>> | Array<Matcher<t.ObjectTypeCallProperty>> | null,
+  internalSlots?: Matcher<Array<t.ObjectTypeInternalSlot>> | Array<Matcher<t.ObjectTypeInternalSlot>> | null,
+  exact?: Matcher<boolean> | boolean,
+): Matcher<t.ObjectTypeAnnotation> {
+  return new ObjectTypeAnnotationMatcher(
+    properties,
+    indexers,
+    callProperties,
+    internalSlots,
+    exact,
+  );
+}
+
+export class ObjectTypeInternalSlotMatcher extends Matcher<t.ObjectTypeInternalSlot> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly value?: Matcher<t.FlowType>,
+    private readonly optional?: Matcher<boolean> | boolean,
+    private readonly _static?: Matcher<boolean> | boolean,
+    private readonly method?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectTypeInternalSlot {
+    if (
+      !isNode(node) ||
+      !t.isObjectTypeInternalSlot(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    if (typeof this.optional === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.optional === 'boolean') {
+      if (this.optional !== node.optional) {
+        return false;
+      }
+    } else if (!this.optional.match(node.optional)) {
+      return false;
+    }
+
+    if (typeof this._static === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this._static === 'boolean') {
+      if (this._static !== node.static) {
+        return false;
+      }
+    } else if (!this._static.match(node.static)) {
+      return false;
+    }
+
+    if (typeof this.method === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.method === 'boolean') {
+      if (this.method !== node.method) {
+        return false;
+      }
+    } else if (!this.method.match(node.method)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectTypeInternalSlot(
+  id?: Matcher<t.Identifier>,
+  value?: Matcher<t.FlowType>,
+  optional?: Matcher<boolean> | boolean,
+  _static?: Matcher<boolean> | boolean,
+  method?: Matcher<boolean> | boolean,
+): Matcher<t.ObjectTypeInternalSlot> {
+  return new ObjectTypeInternalSlotMatcher(
+    id,
+    value,
+    optional,
+    _static,
+    method,
+  );
+}
+
+export class ObjectTypeCallPropertyMatcher extends Matcher<t.ObjectTypeCallProperty> {
+  constructor(
+    private readonly value?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectTypeCallProperty {
+    if (
+      !isNode(node) ||
+      !t.isObjectTypeCallProperty(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectTypeCallProperty(
+  value?: Matcher<t.FlowType>,
+): Matcher<t.ObjectTypeCallProperty> {
+  return new ObjectTypeCallPropertyMatcher(
+    value,
+  );
+}
+
+export class ObjectTypeIndexerMatcher extends Matcher<t.ObjectTypeIndexer> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier> | null,
+    private readonly key?: Matcher<t.FlowType>,
+    private readonly value?: Matcher<t.FlowType>,
+    private readonly variance?: Matcher<t.Variance> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectTypeIndexer {
+    if (
+      !isNode(node) ||
+      !t.isObjectTypeIndexer(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.id === null) {
+      // null matcher means we expect null value
+      if (node.id !== null) {
+        return false;
+      }
+    } else if (node.id === null) {
+      return false;
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    if (typeof this.variance === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.variance === null) {
+      // null matcher means we expect null value
+      if (node.variance !== null) {
+        return false;
+      }
+    } else if (node.variance === null) {
+      return false;
+    } else if (!this.variance.match(node.variance)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectTypeIndexer(
+  id?: Matcher<t.Identifier> | null,
+  key?: Matcher<t.FlowType>,
+  value?: Matcher<t.FlowType>,
+  variance?: Matcher<t.Variance> | null,
+): Matcher<t.ObjectTypeIndexer> {
+  return new ObjectTypeIndexerMatcher(
+    id,
+    key,
+    value,
+    variance,
+  );
+}
+
+export class ObjectTypePropertyMatcher extends Matcher<t.ObjectTypeProperty> {
+  constructor(
+    private readonly key?: Matcher<t.Identifier | t.StringLiteral>,
+    private readonly value?: Matcher<t.FlowType>,
+    private readonly variance?: Matcher<t.Variance> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectTypeProperty {
+    if (
+      !isNode(node) ||
+      !t.isObjectTypeProperty(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    if (typeof this.variance === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.variance === null) {
+      // null matcher means we expect null value
+      if (node.variance !== null) {
+        return false;
+      }
+    } else if (node.variance === null) {
+      return false;
+    } else if (!this.variance.match(node.variance)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectTypeProperty(
+  key?: Matcher<t.Identifier | t.StringLiteral>,
+  value?: Matcher<t.FlowType>,
+  variance?: Matcher<t.Variance> | null,
+): Matcher<t.ObjectTypeProperty> {
+  return new ObjectTypePropertyMatcher(
+    key,
+    value,
+    variance,
+  );
+}
+
+export class ObjectTypeSpreadPropertyMatcher extends Matcher<t.ObjectTypeSpreadProperty> {
+  constructor(
+    private readonly argument?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ObjectTypeSpreadProperty {
+    if (
+      !isNode(node) ||
+      !t.isObjectTypeSpreadProperty(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function objectTypeSpreadProperty(
+  argument?: Matcher<t.FlowType>,
+): Matcher<t.ObjectTypeSpreadProperty> {
+  return new ObjectTypeSpreadPropertyMatcher(
+    argument,
+  );
+}
+
+export class OpaqueTypeMatcher extends Matcher<t.OpaqueType> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+    private readonly supertype?: Matcher<t.FlowType> | null,
+    private readonly impltype?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.OpaqueType {
+    if (
+      !isNode(node) ||
+      !t.isOpaqueType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.supertype === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.supertype === null) {
+      // null matcher means we expect null value
+      if (node.supertype !== null) {
+        return false;
+      }
+    } else if (node.supertype === null) {
+      return false;
+    } else if (!this.supertype.match(node.supertype)) {
+      return false;
+    }
+
+    if (typeof this.impltype === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.impltype.match(node.impltype)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function opaqueType(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+  supertype?: Matcher<t.FlowType> | null,
+  impltype?: Matcher<t.FlowType>,
+): Matcher<t.OpaqueType> {
+  return new OpaqueTypeMatcher(
+    id,
+    typeParameters,
+    supertype,
+    impltype,
+  );
+}
+
+export class QualifiedTypeIdentifierMatcher extends Matcher<t.QualifiedTypeIdentifier> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly qualification?: Matcher<t.Identifier | t.QualifiedTypeIdentifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.QualifiedTypeIdentifier {
+    if (
+      !isNode(node) ||
+      !t.isQualifiedTypeIdentifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.qualification === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.qualification.match(node.qualification)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function qualifiedTypeIdentifier(
+  id?: Matcher<t.Identifier>,
+  qualification?: Matcher<t.Identifier | t.QualifiedTypeIdentifier>,
+): Matcher<t.QualifiedTypeIdentifier> {
+  return new QualifiedTypeIdentifierMatcher(
+    id,
+    qualification,
+  );
+}
+
+export class StringLiteralTypeAnnotationMatcher extends Matcher<t.StringLiteralTypeAnnotation> {
+  constructor(
+    private readonly value?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.StringLiteralTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isStringLiteralTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'string') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function stringLiteralTypeAnnotation(
+  value?: Matcher<string> | string,
+): Matcher<t.StringLiteralTypeAnnotation> {
+  return new StringLiteralTypeAnnotationMatcher(
+    value,
+  );
+}
+
+export class StringTypeAnnotationMatcher extends Matcher<t.StringTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.StringTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isStringTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function stringTypeAnnotation(
+): Matcher<t.StringTypeAnnotation> {
+  return new StringTypeAnnotationMatcher(
+  );
+}
+
+export class ThisTypeAnnotationMatcher extends Matcher<t.ThisTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ThisTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isThisTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function thisTypeAnnotation(
+): Matcher<t.ThisTypeAnnotation> {
+  return new ThisTypeAnnotationMatcher(
+  );
+}
+
+export class TupleTypeAnnotationMatcher extends Matcher<t.TupleTypeAnnotation> {
+  constructor(
+    private readonly types?: Matcher<Array<t.FlowType>> | Array<Matcher<t.FlowType>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TupleTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isTupleTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.types === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.types)) {
+      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+        return false;
+      }
+    } else if (!this.types.match(node.types)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tupleTypeAnnotation(
+  types?: Matcher<Array<t.FlowType>> | Array<Matcher<t.FlowType>>,
+): Matcher<t.TupleTypeAnnotation> {
+  return new TupleTypeAnnotationMatcher(
+    types,
+  );
+}
+
+export class TypeofTypeAnnotationMatcher extends Matcher<t.TypeofTypeAnnotation> {
+  constructor(
+    private readonly argument?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TypeofTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isTypeofTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function typeofTypeAnnotation(
+  argument?: Matcher<t.FlowType>,
+): Matcher<t.TypeofTypeAnnotation> {
+  return new TypeofTypeAnnotationMatcher(
+    argument,
+  );
+}
+
+export class TypeAliasMatcher extends Matcher<t.TypeAlias> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+    private readonly right?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TypeAlias {
+    if (
+      !isNode(node) ||
+      !t.isTypeAlias(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function typeAlias(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TypeParameterDeclaration> | null,
+  right?: Matcher<t.FlowType>,
+): Matcher<t.TypeAlias> {
+  return new TypeAliasMatcher(
+    id,
+    typeParameters,
+    right,
+  );
+}
+
+export class TypeAnnotationMatcher extends Matcher<t.TypeAnnotation> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.FlowType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function typeAnnotation(
+  typeAnnotation?: Matcher<t.FlowType>,
+): Matcher<t.TypeAnnotation> {
+  return new TypeAnnotationMatcher(
+    typeAnnotation,
+  );
+}
+
+export class TypeCastExpressionMatcher extends Matcher<t.TypeCastExpression> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+    private readonly typeAnnotation?: Matcher<t.TypeAnnotation>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TypeCastExpression {
+    if (
+      !isNode(node) ||
+      !t.isTypeCastExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function typeCastExpression(
+  expression?: Matcher<t.Expression>,
+  typeAnnotation?: Matcher<t.TypeAnnotation>,
+): Matcher<t.TypeCastExpression> {
+  return new TypeCastExpressionMatcher(
+    expression,
+    typeAnnotation,
+  );
+}
+
+export class TypeParameterMatcher extends Matcher<t.TypeParameter> {
+  constructor(
+    private readonly bound?: Matcher<t.TypeAnnotation> | null,
+    private readonly _default?: Matcher<t.FlowType> | null,
+    private readonly variance?: Matcher<t.Variance> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TypeParameter {
+    if (
+      !isNode(node) ||
+      !t.isTypeParameter(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.bound === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.bound === null) {
+      // null matcher means we expect null value
+      if (node.bound !== null) {
+        return false;
+      }
+    } else if (node.bound === null) {
+      return false;
+    } else if (!this.bound.match(node.bound)) {
+      return false;
+    }
+
+    if (typeof this._default === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this._default === null) {
+      // null matcher means we expect null value
+      if (node.default !== null) {
+        return false;
+      }
+    } else if (node.default === null) {
+      return false;
+    } else if (!this._default.match(node.default)) {
+      return false;
+    }
+
+    if (typeof this.variance === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.variance === null) {
+      // null matcher means we expect null value
+      if (node.variance !== null) {
+        return false;
+      }
+    } else if (node.variance === null) {
+      return false;
+    } else if (!this.variance.match(node.variance)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function typeParameter(
+  bound?: Matcher<t.TypeAnnotation> | null,
+  _default?: Matcher<t.FlowType> | null,
+  variance?: Matcher<t.Variance> | null,
+): Matcher<t.TypeParameter> {
+  return new TypeParameterMatcher(
+    bound,
+    _default,
+    variance,
+  );
+}
+
+export class TypeParameterDeclarationMatcher extends Matcher<t.TypeParameterDeclaration> {
+  constructor(
+    private readonly params?: Matcher<Array<t.TypeParameter>> | Array<Matcher<t.TypeParameter>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TypeParameterDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTypeParameterDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function typeParameterDeclaration(
+  params?: Matcher<Array<t.TypeParameter>> | Array<Matcher<t.TypeParameter>>,
+): Matcher<t.TypeParameterDeclaration> {
+  return new TypeParameterDeclarationMatcher(
+    params,
+  );
+}
+
+export class TypeParameterInstantiationMatcher extends Matcher<t.TypeParameterInstantiation> {
+  constructor(
+    private readonly params?: Matcher<Array<t.FlowType>> | Array<Matcher<t.FlowType>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TypeParameterInstantiation {
+    if (
+      !isNode(node) ||
+      !t.isTypeParameterInstantiation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function typeParameterInstantiation(
+  params?: Matcher<Array<t.FlowType>> | Array<Matcher<t.FlowType>>,
+): Matcher<t.TypeParameterInstantiation> {
+  return new TypeParameterInstantiationMatcher(
+    params,
+  );
+}
+
+export class UnionTypeAnnotationMatcher extends Matcher<t.UnionTypeAnnotation> {
+  constructor(
+    private readonly types?: Matcher<Array<t.FlowType>> | Array<Matcher<t.FlowType>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.UnionTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isUnionTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.types === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.types)) {
+      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+        return false;
+      }
+    } else if (!this.types.match(node.types)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function unionTypeAnnotation(
+  types?: Matcher<Array<t.FlowType>> | Array<Matcher<t.FlowType>>,
+): Matcher<t.UnionTypeAnnotation> {
+  return new UnionTypeAnnotationMatcher(
+    types,
+  );
+}
+
+export class VarianceMatcher extends Matcher<t.Variance> {
+  constructor(
+    private readonly kind?: Matcher<"minus" | "plus"> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.Variance {
+    if (
+      !isNode(node) ||
+      !t.isVariance(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.kind === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.kind === 'string') {
+      if (this.kind !== node.kind) {
+        return false;
+      }
+    } else if (!this.kind.match(node.kind)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function variance(
+  kind?: Matcher<"minus" | "plus"> | string,
+): Matcher<t.Variance> {
+  return new VarianceMatcher(
+    kind,
+  );
+}
+
+export class VoidTypeAnnotationMatcher extends Matcher<t.VoidTypeAnnotation> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.VoidTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isVoidTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function voidTypeAnnotation(
+): Matcher<t.VoidTypeAnnotation> {
+  return new VoidTypeAnnotationMatcher(
+  );
+}
+
+export class JSXAttributeMatcher extends Matcher<t.JSXAttribute> {
+  constructor(
+    private readonly name?: Matcher<t.JSXIdentifier | t.JSXNamespacedName>,
+    private readonly value?: Matcher<t.JSXElement | t.JSXFragment | t.StringLiteral | t.JSXExpressionContainer> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXAttribute {
+    if (
+      !isNode(node) ||
+      !t.isJSXAttribute(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.name === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.name.match(node.name)) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.value === null) {
+      // null matcher means we expect null value
+      if (node.value !== null) {
+        return false;
+      }
+    } else if (node.value === null) {
+      return false;
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxAttribute(
+  name?: Matcher<t.JSXIdentifier | t.JSXNamespacedName>,
+  value?: Matcher<t.JSXElement | t.JSXFragment | t.StringLiteral | t.JSXExpressionContainer> | null,
+): Matcher<t.JSXAttribute> {
+  return new JSXAttributeMatcher(
+    name,
+    value,
+  );
+}
+
+export class JSXClosingElementMatcher extends Matcher<t.JSXClosingElement> {
+  constructor(
+    private readonly name?: Matcher<t.JSXIdentifier | t.JSXMemberExpression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXClosingElement {
+    if (
+      !isNode(node) ||
+      !t.isJSXClosingElement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.name === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.name.match(node.name)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxClosingElement(
+  name?: Matcher<t.JSXIdentifier | t.JSXMemberExpression>,
+): Matcher<t.JSXClosingElement> {
+  return new JSXClosingElementMatcher(
+    name,
+  );
+}
+
+export class JSXElementMatcher extends Matcher<t.JSXElement> {
+  constructor(
+    private readonly openingElement?: Matcher<t.JSXOpeningElement>,
+    private readonly closingElement?: Matcher<t.JSXClosingElement> | null,
+    private readonly children?: Matcher<Array<t.JSXText | t.JSXExpressionContainer | t.JSXSpreadChild | t.JSXElement | t.JSXFragment>> | Array<Matcher<t.JSXText> | Matcher<t.JSXExpressionContainer> | Matcher<t.JSXSpreadChild> | Matcher<t.JSXElement> | Matcher<t.JSXFragment>>,
+    private readonly selfClosing?: Matcher<any>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXElement {
+    if (
+      !isNode(node) ||
+      !t.isJSXElement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.openingElement === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.openingElement.match(node.openingElement)) {
+      return false;
+    }
+
+    if (typeof this.closingElement === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.closingElement === null) {
+      // null matcher means we expect null value
+      if (node.closingElement !== null) {
+        return false;
+      }
+    } else if (node.closingElement === null) {
+      return false;
+    } else if (!this.closingElement.match(node.closingElement)) {
+      return false;
+    }
+
+    if (typeof this.children === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.children)) {
+      if (!tupleOf<unknown>(...this.children).match(node.children)) {
+        return false;
+      }
+    } else if (!this.children.match(node.children)) {
+      return false;
+    }
+
+    if (typeof this.selfClosing === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.selfClosing.match(node.selfClosing)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxElement(
+  openingElement?: Matcher<t.JSXOpeningElement>,
+  closingElement?: Matcher<t.JSXClosingElement> | null,
+  children?: Matcher<Array<t.JSXText | t.JSXExpressionContainer | t.JSXSpreadChild | t.JSXElement | t.JSXFragment>> | Array<Matcher<t.JSXText> | Matcher<t.JSXExpressionContainer> | Matcher<t.JSXSpreadChild> | Matcher<t.JSXElement> | Matcher<t.JSXFragment>>,
+  selfClosing?: Matcher<any>,
+): Matcher<t.JSXElement> {
+  return new JSXElementMatcher(
+    openingElement,
+    closingElement,
+    children,
+    selfClosing,
+  );
+}
+
+export class JSXEmptyExpressionMatcher extends Matcher<t.JSXEmptyExpression> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXEmptyExpression {
+    if (
+      !isNode(node) ||
+      !t.isJSXEmptyExpression(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxEmptyExpression(
+): Matcher<t.JSXEmptyExpression> {
+  return new JSXEmptyExpressionMatcher(
+  );
+}
+
+export class JSXExpressionContainerMatcher extends Matcher<t.JSXExpressionContainer> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression | t.JSXEmptyExpression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXExpressionContainer {
+    if (
+      !isNode(node) ||
+      !t.isJSXExpressionContainer(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxExpressionContainer(
+  expression?: Matcher<t.Expression | t.JSXEmptyExpression>,
+): Matcher<t.JSXExpressionContainer> {
+  return new JSXExpressionContainerMatcher(
+    expression,
+  );
+}
+
+export class JSXSpreadChildMatcher extends Matcher<t.JSXSpreadChild> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXSpreadChild {
+    if (
+      !isNode(node) ||
+      !t.isJSXSpreadChild(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxSpreadChild(
+  expression?: Matcher<t.Expression>,
+): Matcher<t.JSXSpreadChild> {
+  return new JSXSpreadChildMatcher(
+    expression,
+  );
+}
+
+export class JSXIdentifierMatcher extends Matcher<t.JSXIdentifier> {
+  constructor(
+    private readonly name?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXIdentifier {
+    if (
+      !isNode(node) ||
+      !t.isJSXIdentifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.name === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.name === 'string') {
+      if (this.name !== node.name) {
+        return false;
+      }
+    } else if (!this.name.match(node.name)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxIdentifier(
+  name?: Matcher<string> | string,
+): Matcher<t.JSXIdentifier> {
+  return new JSXIdentifierMatcher(
+    name,
+  );
+}
+
+export class JSXMemberExpressionMatcher extends Matcher<t.JSXMemberExpression> {
+  constructor(
+    private readonly object?: Matcher<t.JSXMemberExpression | t.JSXIdentifier>,
+    private readonly property?: Matcher<t.JSXIdentifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXMemberExpression {
+    if (
+      !isNode(node) ||
+      !t.isJSXMemberExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.object === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.object.match(node.object)) {
+      return false;
+    }
+
+    if (typeof this.property === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.property.match(node.property)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxMemberExpression(
+  object?: Matcher<t.JSXMemberExpression | t.JSXIdentifier>,
+  property?: Matcher<t.JSXIdentifier>,
+): Matcher<t.JSXMemberExpression> {
+  return new JSXMemberExpressionMatcher(
+    object,
+    property,
+  );
+}
+
+export class JSXNamespacedNameMatcher extends Matcher<t.JSXNamespacedName> {
+  constructor(
+    private readonly namespace?: Matcher<t.JSXIdentifier>,
+    private readonly name?: Matcher<t.JSXIdentifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXNamespacedName {
+    if (
+      !isNode(node) ||
+      !t.isJSXNamespacedName(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.namespace === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.namespace.match(node.namespace)) {
+      return false;
+    }
+
+    if (typeof this.name === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.name.match(node.name)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxNamespacedName(
+  namespace?: Matcher<t.JSXIdentifier>,
+  name?: Matcher<t.JSXIdentifier>,
+): Matcher<t.JSXNamespacedName> {
+  return new JSXNamespacedNameMatcher(
+    namespace,
+    name,
+  );
+}
+
+export class JSXOpeningElementMatcher extends Matcher<t.JSXOpeningElement> {
+  constructor(
+    private readonly name?: Matcher<t.JSXIdentifier | t.JSXMemberExpression>,
+    private readonly attributes?: Matcher<Array<t.JSXAttribute | t.JSXSpreadAttribute>> | Array<Matcher<t.JSXAttribute> | Matcher<t.JSXSpreadAttribute>>,
+    private readonly selfClosing?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXOpeningElement {
+    if (
+      !isNode(node) ||
+      !t.isJSXOpeningElement(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.name === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.name.match(node.name)) {
+      return false;
+    }
+
+    if (typeof this.attributes === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.attributes)) {
+      if (!tupleOf<unknown>(...this.attributes).match(node.attributes)) {
+        return false;
+      }
+    } else if (!this.attributes.match(node.attributes)) {
+      return false;
+    }
+
+    if (typeof this.selfClosing === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.selfClosing === 'boolean') {
+      if (this.selfClosing !== node.selfClosing) {
+        return false;
+      }
+    } else if (!this.selfClosing.match(node.selfClosing)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxOpeningElement(
+  name?: Matcher<t.JSXIdentifier | t.JSXMemberExpression>,
+  attributes?: Matcher<Array<t.JSXAttribute | t.JSXSpreadAttribute>> | Array<Matcher<t.JSXAttribute> | Matcher<t.JSXSpreadAttribute>>,
+  selfClosing?: Matcher<boolean> | boolean,
+): Matcher<t.JSXOpeningElement> {
+  return new JSXOpeningElementMatcher(
+    name,
+    attributes,
+    selfClosing,
+  );
+}
+
+export class JSXSpreadAttributeMatcher extends Matcher<t.JSXSpreadAttribute> {
+  constructor(
+    private readonly argument?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXSpreadAttribute {
+    if (
+      !isNode(node) ||
+      !t.isJSXSpreadAttribute(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxSpreadAttribute(
+  argument?: Matcher<t.Expression>,
+): Matcher<t.JSXSpreadAttribute> {
+  return new JSXSpreadAttributeMatcher(
+    argument,
+  );
+}
+
+export class JSXTextMatcher extends Matcher<t.JSXText> {
+  constructor(
+    private readonly value?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXText {
+    if (
+      !isNode(node) ||
+      !t.isJSXText(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'string') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxText(
+  value?: Matcher<string> | string,
+): Matcher<t.JSXText> {
+  return new JSXTextMatcher(
+    value,
+  );
+}
+
+export class JSXFragmentMatcher extends Matcher<t.JSXFragment> {
+  constructor(
+    private readonly openingFragment?: Matcher<t.JSXOpeningFragment>,
+    private readonly closingFragment?: Matcher<t.JSXClosingFragment>,
+    private readonly children?: Matcher<Array<t.JSXText | t.JSXExpressionContainer | t.JSXSpreadChild | t.JSXElement | t.JSXFragment>> | Array<Matcher<t.JSXText> | Matcher<t.JSXExpressionContainer> | Matcher<t.JSXSpreadChild> | Matcher<t.JSXElement> | Matcher<t.JSXFragment>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXFragment {
+    if (
+      !isNode(node) ||
+      !t.isJSXFragment(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.openingFragment === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.openingFragment.match(node.openingFragment)) {
+      return false;
+    }
+
+    if (typeof this.closingFragment === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.closingFragment.match(node.closingFragment)) {
+      return false;
+    }
+
+    if (typeof this.children === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.children)) {
+      if (!tupleOf<unknown>(...this.children).match(node.children)) {
+        return false;
+      }
+    } else if (!this.children.match(node.children)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxFragment(
+  openingFragment?: Matcher<t.JSXOpeningFragment>,
+  closingFragment?: Matcher<t.JSXClosingFragment>,
+  children?: Matcher<Array<t.JSXText | t.JSXExpressionContainer | t.JSXSpreadChild | t.JSXElement | t.JSXFragment>> | Array<Matcher<t.JSXText> | Matcher<t.JSXExpressionContainer> | Matcher<t.JSXSpreadChild> | Matcher<t.JSXElement> | Matcher<t.JSXFragment>>,
+): Matcher<t.JSXFragment> {
+  return new JSXFragmentMatcher(
+    openingFragment,
+    closingFragment,
+    children,
+  );
+}
+
+export class JSXOpeningFragmentMatcher extends Matcher<t.JSXOpeningFragment> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXOpeningFragment {
+    if (
+      !isNode(node) ||
+      !t.isJSXOpeningFragment(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxOpeningFragment(
+): Matcher<t.JSXOpeningFragment> {
+  return new JSXOpeningFragmentMatcher(
+  );
+}
+
+export class JSXClosingFragmentMatcher extends Matcher<t.JSXClosingFragment> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.JSXClosingFragment {
+    if (
+      !isNode(node) ||
+      !t.isJSXClosingFragment(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function jsxClosingFragment(
+): Matcher<t.JSXClosingFragment> {
+  return new JSXClosingFragmentMatcher(
+  );
+}
+
+export class NoopMatcher extends Matcher<t.Noop> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.Noop {
+    if (
+      !isNode(node) ||
+      !t.isNoop(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function noop(
+): Matcher<t.Noop> {
+  return new NoopMatcher(
+  );
+}
+
+export class ParenthesizedExpressionMatcher extends Matcher<t.ParenthesizedExpression> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ParenthesizedExpression {
+    if (
+      !isNode(node) ||
+      !t.isParenthesizedExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function parenthesizedExpression(
+  expression?: Matcher<t.Expression>,
+): Matcher<t.ParenthesizedExpression> {
+  return new ParenthesizedExpressionMatcher(
+    expression,
+  );
+}
+
+export class AwaitExpressionMatcher extends Matcher<t.AwaitExpression> {
+  constructor(
+    private readonly argument?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.AwaitExpression {
+    if (
+      !isNode(node) ||
+      !t.isAwaitExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function awaitExpression(
+  argument?: Matcher<t.Expression>,
+): Matcher<t.AwaitExpression> {
+  return new AwaitExpressionMatcher(
+    argument,
+  );
+}
+
+export class BindExpressionMatcher extends Matcher<t.BindExpression> {
+  constructor(
+    private readonly object?: Matcher<any>,
+    private readonly callee?: Matcher<any>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.BindExpression {
+    if (
+      !isNode(node) ||
+      !t.isBindExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.object === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.object.match(node.object)) {
+      return false;
+    }
+
+    if (typeof this.callee === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.callee.match(node.callee)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function bindExpression(
+  object?: Matcher<any>,
+  callee?: Matcher<any>,
+): Matcher<t.BindExpression> {
+  return new BindExpressionMatcher(
+    object,
+    callee,
+  );
+}
+
+export class ClassPropertyMatcher extends Matcher<t.ClassProperty> {
+  constructor(
+    private readonly key?: Matcher<t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression>,
+    private readonly value?: Matcher<t.Expression> | null,
+    private readonly typeAnnotation?: Matcher<t.TypeAnnotation | t.TSTypeAnnotation | t.Noop> | null,
+    private readonly decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+    private readonly computed?: Matcher<boolean> | boolean | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ClassProperty {
+    if (
+      !isNode(node) ||
+      !t.isClassProperty(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.value === null) {
+      // null matcher means we expect null value
+      if (node.value !== null) {
+        return false;
+      }
+    } else if (node.value === null) {
+      return false;
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    if (typeof this.decorators === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.decorators === null) {
+      // null matcher means we expect null value
+      if (node.decorators !== null) {
+        return false;
+      }
+    } else if (node.decorators === null) {
+      return false;
+    } else if (Array.isArray(this.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+        return false;
+      }
+    } else if (!this.decorators.match(node.decorators)) {
+      return false;
+    }
+
+    if (typeof this.computed === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.computed === 'boolean') {
+      if (this.computed !== node.computed) {
+        return false;
+      }
+    } else if (this.computed === null) {
+      // null matcher means we expect null value
+      if (node.computed !== null) {
+        return false;
+      }
+    } else if (node.computed === null) {
+      return false;
+    } else if (!this.computed.match(node.computed)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function classProperty(
+  key?: Matcher<t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression>,
+  value?: Matcher<t.Expression> | null,
+  typeAnnotation?: Matcher<t.TypeAnnotation | t.TSTypeAnnotation | t.Noop> | null,
+  decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+  computed?: Matcher<boolean> | boolean | null,
+): Matcher<t.ClassProperty> {
+  return new ClassPropertyMatcher(
+    key,
+    value,
+    typeAnnotation,
+    decorators,
+    computed,
+  );
+}
+
+export class OptionalMemberExpressionMatcher extends Matcher<t.OptionalMemberExpression> {
+  constructor(
+    private readonly object?: Matcher<t.Expression>,
+    private readonly property?: Matcher<any>,
+    private readonly computed?: Matcher<boolean> | boolean,
+    private readonly optional?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.OptionalMemberExpression {
+    if (
+      !isNode(node) ||
+      !t.isOptionalMemberExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.object === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.object.match(node.object)) {
+      return false;
+    }
+
+    if (typeof this.property === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.property.match(node.property)) {
+      return false;
+    }
+
+    if (typeof this.computed === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.computed === 'boolean') {
+      if (this.computed !== node.computed) {
+        return false;
+      }
+    } else if (!this.computed.match(node.computed)) {
+      return false;
+    }
+
+    if (typeof this.optional === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.optional === 'boolean') {
+      if (this.optional !== node.optional) {
+        return false;
+      }
+    } else if (!this.optional.match(node.optional)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function optionalMemberExpression(
+  object?: Matcher<t.Expression>,
+  property?: Matcher<any>,
+  computed?: Matcher<boolean> | boolean,
+  optional?: Matcher<boolean> | boolean,
+): Matcher<t.OptionalMemberExpression> {
+  return new OptionalMemberExpressionMatcher(
+    object,
+    property,
+    computed,
+    optional,
+  );
+}
+
+export class PipelineTopicExpressionMatcher extends Matcher<t.PipelineTopicExpression> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.PipelineTopicExpression {
+    if (
+      !isNode(node) ||
+      !t.isPipelineTopicExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function pipelineTopicExpression(
+  expression?: Matcher<t.Expression>,
+): Matcher<t.PipelineTopicExpression> {
+  return new PipelineTopicExpressionMatcher(
+    expression,
+  );
+}
+
+export class PipelineBareFunctionMatcher extends Matcher<t.PipelineBareFunction> {
+  constructor(
+    private readonly callee?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.PipelineBareFunction {
+    if (
+      !isNode(node) ||
+      !t.isPipelineBareFunction(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.callee === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.callee.match(node.callee)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function pipelineBareFunction(
+  callee?: Matcher<t.Expression>,
+): Matcher<t.PipelineBareFunction> {
+  return new PipelineBareFunctionMatcher(
+    callee,
+  );
+}
+
+export class PipelinePrimaryTopicReferenceMatcher extends Matcher<t.PipelinePrimaryTopicReference> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.PipelinePrimaryTopicReference {
+    if (
+      !isNode(node) ||
+      !t.isPipelinePrimaryTopicReference(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function pipelinePrimaryTopicReference(
+): Matcher<t.PipelinePrimaryTopicReference> {
+  return new PipelinePrimaryTopicReferenceMatcher(
+  );
+}
+
+export class OptionalCallExpressionMatcher extends Matcher<t.OptionalCallExpression> {
+  constructor(
+    private readonly callee?: Matcher<t.Expression>,
+    private readonly _arguments?: Matcher<Array<t.Expression | t.SpreadElement | t.JSXNamespacedName>> | Array<Matcher<t.Expression> | Matcher<t.SpreadElement> | Matcher<t.JSXNamespacedName>>,
+    private readonly optional?: Matcher<boolean> | boolean,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.OptionalCallExpression {
+    if (
+      !isNode(node) ||
+      !t.isOptionalCallExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.callee === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.callee.match(node.callee)) {
+      return false;
+    }
+
+    if (typeof this._arguments === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this._arguments)) {
+      if (!tupleOf<unknown>(...this._arguments).match(node.arguments)) {
+        return false;
+      }
+    } else if (!this._arguments.match(node.arguments)) {
+      return false;
+    }
+
+    if (typeof this.optional === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.optional === 'boolean') {
+      if (this.optional !== node.optional) {
+        return false;
+      }
+    } else if (!this.optional.match(node.optional)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function optionalCallExpression(
+  callee?: Matcher<t.Expression>,
+  _arguments?: Matcher<Array<t.Expression | t.SpreadElement | t.JSXNamespacedName>> | Array<Matcher<t.Expression> | Matcher<t.SpreadElement> | Matcher<t.JSXNamespacedName>>,
+  optional?: Matcher<boolean> | boolean,
+): Matcher<t.OptionalCallExpression> {
+  return new OptionalCallExpressionMatcher(
+    callee,
+    _arguments,
+    optional,
+  );
+}
+
+export class ClassPrivatePropertyMatcher extends Matcher<t.ClassPrivateProperty> {
+  constructor(
+    private readonly key?: Matcher<t.PrivateName>,
+    private readonly value?: Matcher<t.Expression> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ClassPrivateProperty {
+    if (
+      !isNode(node) ||
+      !t.isClassPrivateProperty(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.value === null) {
+      // null matcher means we expect null value
+      if (node.value !== null) {
+        return false;
+      }
+    } else if (node.value === null) {
+      return false;
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function classPrivateProperty(
+  key?: Matcher<t.PrivateName>,
+  value?: Matcher<t.Expression> | null,
+): Matcher<t.ClassPrivateProperty> {
+  return new ClassPrivatePropertyMatcher(
+    key,
+    value,
+  );
+}
+
+export class ClassPrivateMethodMatcher extends Matcher<t.ClassPrivateMethod> {
+  constructor(
+    private readonly kind?: Matcher<"get" | "set" | "method" | "constructor"> | string | null,
+    private readonly key?: Matcher<t.PrivateName>,
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly body?: Matcher<t.BlockStatement>,
+    private readonly _static?: Matcher<boolean> | boolean | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ClassPrivateMethod {
+    if (
+      !isNode(node) ||
+      !t.isClassPrivateMethod(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.kind === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.kind === 'string') {
+      if (this.kind !== node.kind) {
+        return false;
+      }
+    } else if (this.kind === null) {
+      // null matcher means we expect null value
+      if (node.kind !== null) {
+        return false;
+      }
+    } else if (node.kind === null) {
+      return false;
+    } else if (!this.kind.match(node.kind)) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    if (typeof this._static === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this._static === 'boolean') {
+      if (this._static !== node.static) {
+        return false;
+      }
+    } else if (this._static === null) {
+      // null matcher means we expect null value
+      if (node.static !== null) {
+        return false;
+      }
+    } else if (node.static === null) {
+      return false;
+    } else if (!this._static.match(node.static)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function classPrivateMethod(
+  kind?: Matcher<"get" | "set" | "method" | "constructor"> | string | null,
+  key?: Matcher<t.PrivateName>,
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  body?: Matcher<t.BlockStatement>,
+  _static?: Matcher<boolean> | boolean | null,
+): Matcher<t.ClassPrivateMethod> {
+  return new ClassPrivateMethodMatcher(
+    kind,
+    key,
+    params,
+    body,
+    _static,
+  );
+}
+
+export class ImportMatcher extends Matcher<t.Import> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.Import {
+    if (
+      !isNode(node) ||
+      !t.isImport(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function Import(
+): Matcher<t.Import> {
+  return new ImportMatcher(
+  );
+}
+
+export class DecoratorMatcher extends Matcher<t.Decorator> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.Decorator {
+    if (
+      !isNode(node) ||
+      !t.isDecorator(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function decorator(
+  expression?: Matcher<t.Expression>,
+): Matcher<t.Decorator> {
+  return new DecoratorMatcher(
+    expression,
+  );
+}
+
+export class DoExpressionMatcher extends Matcher<t.DoExpression> {
+  constructor(
+    private readonly body?: Matcher<t.BlockStatement>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.DoExpression {
+    if (
+      !isNode(node) ||
+      !t.isDoExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function doExpression(
+  body?: Matcher<t.BlockStatement>,
+): Matcher<t.DoExpression> {
+  return new DoExpressionMatcher(
+    body,
+  );
+}
+
+export class ExportDefaultSpecifierMatcher extends Matcher<t.ExportDefaultSpecifier> {
+  constructor(
+    private readonly exported?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ExportDefaultSpecifier {
+    if (
+      !isNode(node) ||
+      !t.isExportDefaultSpecifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.exported === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.exported.match(node.exported)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function exportDefaultSpecifier(
+  exported?: Matcher<t.Identifier>,
+): Matcher<t.ExportDefaultSpecifier> {
+  return new ExportDefaultSpecifierMatcher(
+    exported,
+  );
+}
+
+export class ExportNamespaceSpecifierMatcher extends Matcher<t.ExportNamespaceSpecifier> {
+  constructor(
+    private readonly exported?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.ExportNamespaceSpecifier {
+    if (
+      !isNode(node) ||
+      !t.isExportNamespaceSpecifier(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.exported === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.exported.match(node.exported)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function exportNamespaceSpecifier(
+  exported?: Matcher<t.Identifier>,
+): Matcher<t.ExportNamespaceSpecifier> {
+  return new ExportNamespaceSpecifierMatcher(
+    exported,
+  );
+}
+
+export class PrivateNameMatcher extends Matcher<t.PrivateName> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.PrivateName {
+    if (
+      !isNode(node) ||
+      !t.isPrivateName(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function privateName(
+  id?: Matcher<t.Identifier>,
+): Matcher<t.PrivateName> {
+  return new PrivateNameMatcher(
+    id,
+  );
+}
+
+export class BigIntLiteralMatcher extends Matcher<t.BigIntLiteral> {
+  constructor(
+    private readonly value?: Matcher<string> | string,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.BigIntLiteral {
+    if (
+      !isNode(node) ||
+      !t.isBigIntLiteral(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.value === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (typeof this.value === 'string') {
+      if (this.value !== node.value) {
+        return false;
+      }
+    } else if (!this.value.match(node.value)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function bigIntLiteral(
+  value?: Matcher<string> | string,
+): Matcher<t.BigIntLiteral> {
+  return new BigIntLiteralMatcher(
+    value,
+  );
+}
+
+export class TSParameterPropertyMatcher extends Matcher<t.TSParameterProperty> {
+  constructor(
+    private readonly parameter?: Matcher<t.Identifier | t.AssignmentPattern>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSParameterProperty {
+    if (
+      !isNode(node) ||
+      !t.isTSParameterProperty(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.parameter === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.parameter.match(node.parameter)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsParameterProperty(
+  parameter?: Matcher<t.Identifier | t.AssignmentPattern>,
+): Matcher<t.TSParameterProperty> {
+  return new TSParameterPropertyMatcher(
+    parameter,
+  );
+}
+
+export class TSDeclareFunctionMatcher extends Matcher<t.TSDeclareFunction> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier> | null,
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration | t.Noop> | null,
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly returnType?: Matcher<t.TSTypeAnnotation | t.Noop> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSDeclareFunction {
+    if (
+      !isNode(node) ||
+      !t.isTSDeclareFunction(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.id === null) {
+      // null matcher means we expect null value
+      if (node.id !== null) {
+        return false;
+      }
+    } else if (node.id === null) {
+      return false;
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.returnType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.returnType === null) {
+      // null matcher means we expect null value
+      if (node.returnType !== null) {
+        return false;
+      }
+    } else if (node.returnType === null) {
+      return false;
+    } else if (!this.returnType.match(node.returnType)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsDeclareFunction(
+  id?: Matcher<t.Identifier> | null,
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration | t.Noop> | null,
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  returnType?: Matcher<t.TSTypeAnnotation | t.Noop> | null,
+): Matcher<t.TSDeclareFunction> {
+  return new TSDeclareFunctionMatcher(
+    id,
+    typeParameters,
+    params,
+    returnType,
+  );
+}
+
+export class TSDeclareMethodMatcher extends Matcher<t.TSDeclareMethod> {
+  constructor(
+    private readonly decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+    private readonly key?: Matcher<t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression>,
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration | t.Noop> | null,
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly returnType?: Matcher<t.TSTypeAnnotation | t.Noop> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSDeclareMethod {
+    if (
+      !isNode(node) ||
+      !t.isTSDeclareMethod(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.decorators === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.decorators === null) {
+      // null matcher means we expect null value
+      if (node.decorators !== null) {
+        return false;
+      }
+    } else if (node.decorators === null) {
+      return false;
+    } else if (Array.isArray(this.decorators)) {
+      if (!tupleOf<unknown>(...this.decorators).match(node.decorators)) {
+        return false;
+      }
+    } else if (!this.decorators.match(node.decorators)) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    if (typeof this.returnType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.returnType === null) {
+      // null matcher means we expect null value
+      if (node.returnType !== null) {
+        return false;
+      }
+    } else if (node.returnType === null) {
+      return false;
+    } else if (!this.returnType.match(node.returnType)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsDeclareMethod(
+  decorators?: Matcher<Array<t.Decorator>> | Array<Matcher<t.Decorator>> | null,
+  key?: Matcher<t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression>,
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration | t.Noop> | null,
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  returnType?: Matcher<t.TSTypeAnnotation | t.Noop> | null,
+): Matcher<t.TSDeclareMethod> {
+  return new TSDeclareMethodMatcher(
+    decorators,
+    key,
+    typeParameters,
+    params,
+    returnType,
+  );
+}
+
+export class TSQualifiedNameMatcher extends Matcher<t.TSQualifiedName> {
+  constructor(
+    private readonly left?: Matcher<t.TSEntityName>,
+    private readonly right?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSQualifiedName {
+    if (
+      !isNode(node) ||
+      !t.isTSQualifiedName(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.left === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.left.match(node.left)) {
+      return false;
+    }
+
+    if (typeof this.right === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.right.match(node.right)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsQualifiedName(
+  left?: Matcher<t.TSEntityName>,
+  right?: Matcher<t.Identifier>,
+): Matcher<t.TSQualifiedName> {
+  return new TSQualifiedNameMatcher(
+    left,
+    right,
+  );
+}
+
+export class TSCallSignatureDeclarationMatcher extends Matcher<t.TSCallSignatureDeclaration> {
+  constructor(
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+    private readonly parameters?: Matcher<Array<t.Identifier | t.RestElement>> | Array<Matcher<t.Identifier> | Matcher<t.RestElement>> | null,
+    private readonly typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSCallSignatureDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSCallSignatureDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.parameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.parameters === null) {
+      // null matcher means we expect null value
+      if (node.parameters !== null) {
+        return false;
+      }
+    } else if (node.parameters === null) {
+      return false;
+    } else if (Array.isArray(this.parameters)) {
+      if (!tupleOf<unknown>(...this.parameters).match(node.parameters)) {
+        return false;
+      }
+    } else if (!this.parameters.match(node.parameters)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsCallSignatureDeclaration(
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+  parameters?: Matcher<Array<t.Identifier | t.RestElement>> | Array<Matcher<t.Identifier> | Matcher<t.RestElement>> | null,
+  typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+): Matcher<t.TSCallSignatureDeclaration> {
+  return new TSCallSignatureDeclarationMatcher(
+    typeParameters,
+    parameters,
+    typeAnnotation,
+  );
+}
+
+export class TSConstructSignatureDeclarationMatcher extends Matcher<t.TSConstructSignatureDeclaration> {
+  constructor(
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+    private readonly parameters?: Matcher<Array<t.Identifier | t.RestElement>> | Array<Matcher<t.Identifier> | Matcher<t.RestElement>> | null,
+    private readonly typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSConstructSignatureDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSConstructSignatureDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.parameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.parameters === null) {
+      // null matcher means we expect null value
+      if (node.parameters !== null) {
+        return false;
+      }
+    } else if (node.parameters === null) {
+      return false;
+    } else if (Array.isArray(this.parameters)) {
+      if (!tupleOf<unknown>(...this.parameters).match(node.parameters)) {
+        return false;
+      }
+    } else if (!this.parameters.match(node.parameters)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsConstructSignatureDeclaration(
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+  parameters?: Matcher<Array<t.Identifier | t.RestElement>> | Array<Matcher<t.Identifier> | Matcher<t.RestElement>> | null,
+  typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+): Matcher<t.TSConstructSignatureDeclaration> {
+  return new TSConstructSignatureDeclarationMatcher(
+    typeParameters,
+    parameters,
+    typeAnnotation,
+  );
+}
+
+export class TSPropertySignatureMatcher extends Matcher<t.TSPropertySignature> {
+  constructor(
+    private readonly key?: Matcher<t.Expression>,
+    private readonly typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+    private readonly initializer?: Matcher<t.Expression> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSPropertySignature {
+    if (
+      !isNode(node) ||
+      !t.isTSPropertySignature(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    if (typeof this.initializer === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.initializer === null) {
+      // null matcher means we expect null value
+      if (node.initializer !== null) {
+        return false;
+      }
+    } else if (node.initializer === null) {
+      return false;
+    } else if (!this.initializer.match(node.initializer)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsPropertySignature(
+  key?: Matcher<t.Expression>,
+  typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+  initializer?: Matcher<t.Expression> | null,
+): Matcher<t.TSPropertySignature> {
+  return new TSPropertySignatureMatcher(
+    key,
+    typeAnnotation,
+    initializer,
+  );
+}
+
+export class TSMethodSignatureMatcher extends Matcher<t.TSMethodSignature> {
+  constructor(
+    private readonly key?: Matcher<t.Expression>,
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+    private readonly parameters?: Matcher<Array<t.Identifier | t.RestElement>> | Array<Matcher<t.Identifier> | Matcher<t.RestElement>> | null,
+    private readonly typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSMethodSignature {
+    if (
+      !isNode(node) ||
+      !t.isTSMethodSignature(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.key === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.key.match(node.key)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.parameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.parameters === null) {
+      // null matcher means we expect null value
+      if (node.parameters !== null) {
+        return false;
+      }
+    } else if (node.parameters === null) {
+      return false;
+    } else if (Array.isArray(this.parameters)) {
+      if (!tupleOf<unknown>(...this.parameters).match(node.parameters)) {
+        return false;
+      }
+    } else if (!this.parameters.match(node.parameters)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsMethodSignature(
+  key?: Matcher<t.Expression>,
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+  parameters?: Matcher<Array<t.Identifier | t.RestElement>> | Array<Matcher<t.Identifier> | Matcher<t.RestElement>> | null,
+  typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+): Matcher<t.TSMethodSignature> {
+  return new TSMethodSignatureMatcher(
+    key,
+    typeParameters,
+    parameters,
+    typeAnnotation,
+  );
+}
+
+export class TSIndexSignatureMatcher extends Matcher<t.TSIndexSignature> {
+  constructor(
+    private readonly parameters?: Matcher<Array<t.Identifier>> | Array<Matcher<t.Identifier>>,
+    private readonly typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSIndexSignature {
+    if (
+      !isNode(node) ||
+      !t.isTSIndexSignature(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.parameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.parameters)) {
+      if (!tupleOf<unknown>(...this.parameters).match(node.parameters)) {
+        return false;
+      }
+    } else if (!this.parameters.match(node.parameters)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsIndexSignature(
+  parameters?: Matcher<Array<t.Identifier>> | Array<Matcher<t.Identifier>>,
+  typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+): Matcher<t.TSIndexSignature> {
+  return new TSIndexSignatureMatcher(
+    parameters,
+    typeAnnotation,
+  );
+}
+
+export class TSAnyKeywordMatcher extends Matcher<t.TSAnyKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSAnyKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSAnyKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsAnyKeyword(
+): Matcher<t.TSAnyKeyword> {
+  return new TSAnyKeywordMatcher(
+  );
+}
+
+export class TSUnknownKeywordMatcher extends Matcher<t.TSUnknownKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSUnknownKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSUnknownKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsUnknownKeyword(
+): Matcher<t.TSUnknownKeyword> {
+  return new TSUnknownKeywordMatcher(
+  );
+}
+
+export class TSNumberKeywordMatcher extends Matcher<t.TSNumberKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSNumberKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSNumberKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsNumberKeyword(
+): Matcher<t.TSNumberKeyword> {
+  return new TSNumberKeywordMatcher(
+  );
+}
+
+export class TSObjectKeywordMatcher extends Matcher<t.TSObjectKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSObjectKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSObjectKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsObjectKeyword(
+): Matcher<t.TSObjectKeyword> {
+  return new TSObjectKeywordMatcher(
+  );
+}
+
+export class TSBooleanKeywordMatcher extends Matcher<t.TSBooleanKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSBooleanKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSBooleanKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsBooleanKeyword(
+): Matcher<t.TSBooleanKeyword> {
+  return new TSBooleanKeywordMatcher(
+  );
+}
+
+export class TSStringKeywordMatcher extends Matcher<t.TSStringKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSStringKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSStringKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsStringKeyword(
+): Matcher<t.TSStringKeyword> {
+  return new TSStringKeywordMatcher(
+  );
+}
+
+export class TSSymbolKeywordMatcher extends Matcher<t.TSSymbolKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSSymbolKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSSymbolKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsSymbolKeyword(
+): Matcher<t.TSSymbolKeyword> {
+  return new TSSymbolKeywordMatcher(
+  );
+}
+
+export class TSVoidKeywordMatcher extends Matcher<t.TSVoidKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSVoidKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSVoidKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsVoidKeyword(
+): Matcher<t.TSVoidKeyword> {
+  return new TSVoidKeywordMatcher(
+  );
+}
+
+export class TSUndefinedKeywordMatcher extends Matcher<t.TSUndefinedKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSUndefinedKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSUndefinedKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsUndefinedKeyword(
+): Matcher<t.TSUndefinedKeyword> {
+  return new TSUndefinedKeywordMatcher(
+  );
+}
+
+export class TSNullKeywordMatcher extends Matcher<t.TSNullKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSNullKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSNullKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsNullKeyword(
+): Matcher<t.TSNullKeyword> {
+  return new TSNullKeywordMatcher(
+  );
+}
+
+export class TSNeverKeywordMatcher extends Matcher<t.TSNeverKeyword> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSNeverKeyword {
+    if (
+      !isNode(node) ||
+      !t.isTSNeverKeyword(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsNeverKeyword(
+): Matcher<t.TSNeverKeyword> {
+  return new TSNeverKeywordMatcher(
+  );
+}
+
+export class TSThisTypeMatcher extends Matcher<t.TSThisType> {
+  constructor(
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSThisType {
+    if (
+      !isNode(node) ||
+      !t.isTSThisType(node)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsThisType(
+): Matcher<t.TSThisType> {
+  return new TSThisTypeMatcher(
+  );
+}
+
+export class TSFunctionTypeMatcher extends Matcher<t.TSFunctionType> {
+  constructor(
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+    private readonly typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSFunctionType {
+    if (
+      !isNode(node) ||
+      !t.isTSFunctionType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsFunctionType(
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+  typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+): Matcher<t.TSFunctionType> {
+  return new TSFunctionTypeMatcher(
+    typeParameters,
+    typeAnnotation,
+  );
+}
+
+export class TSConstructorTypeMatcher extends Matcher<t.TSConstructorType> {
+  constructor(
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+    private readonly typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSConstructorType {
+    if (
+      !isNode(node) ||
+      !t.isTSConstructorType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsConstructorType(
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+  typeAnnotation?: Matcher<t.TSTypeAnnotation> | null,
+): Matcher<t.TSConstructorType> {
+  return new TSConstructorTypeMatcher(
+    typeParameters,
+    typeAnnotation,
+  );
+}
+
+export class TSTypeReferenceMatcher extends Matcher<t.TSTypeReference> {
+  constructor(
+    private readonly typeName?: Matcher<t.TSEntityName>,
+    private readonly typeParameters?: Matcher<t.TSTypeParameterInstantiation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeReference {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeReference(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeName === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeName.match(node.typeName)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeReference(
+  typeName?: Matcher<t.TSEntityName>,
+  typeParameters?: Matcher<t.TSTypeParameterInstantiation> | null,
+): Matcher<t.TSTypeReference> {
+  return new TSTypeReferenceMatcher(
+    typeName,
+    typeParameters,
+  );
+}
+
+export class TSTypePredicateMatcher extends Matcher<t.TSTypePredicate> {
+  constructor(
+    private readonly parameterName?: Matcher<t.Identifier | t.TSThisType>,
+    private readonly typeAnnotation?: Matcher<t.TSTypeAnnotation>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypePredicate {
+    if (
+      !isNode(node) ||
+      !t.isTSTypePredicate(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.parameterName === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.parameterName.match(node.parameterName)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypePredicate(
+  parameterName?: Matcher<t.Identifier | t.TSThisType>,
+  typeAnnotation?: Matcher<t.TSTypeAnnotation>,
+): Matcher<t.TSTypePredicate> {
+  return new TSTypePredicateMatcher(
+    parameterName,
+    typeAnnotation,
+  );
+}
+
+export class TSTypeQueryMatcher extends Matcher<t.TSTypeQuery> {
+  constructor(
+    private readonly exprName?: Matcher<t.TSEntityName | t.TSImportType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeQuery {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeQuery(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.exprName === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.exprName.match(node.exprName)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeQuery(
+  exprName?: Matcher<t.TSEntityName | t.TSImportType>,
+): Matcher<t.TSTypeQuery> {
+  return new TSTypeQueryMatcher(
+    exprName,
+  );
+}
+
+export class TSTypeLiteralMatcher extends Matcher<t.TSTypeLiteral> {
+  constructor(
+    private readonly members?: Matcher<Array<t.TSTypeElement>> | Array<Matcher<t.TSTypeElement>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeLiteral {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeLiteral(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.members === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.members)) {
+      if (!tupleOf<unknown>(...this.members).match(node.members)) {
+        return false;
+      }
+    } else if (!this.members.match(node.members)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeLiteral(
+  members?: Matcher<Array<t.TSTypeElement>> | Array<Matcher<t.TSTypeElement>>,
+): Matcher<t.TSTypeLiteral> {
+  return new TSTypeLiteralMatcher(
+    members,
+  );
+}
+
+export class TSArrayTypeMatcher extends Matcher<t.TSArrayType> {
+  constructor(
+    private readonly elementType?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSArrayType {
+    if (
+      !isNode(node) ||
+      !t.isTSArrayType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.elementType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.elementType.match(node.elementType)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsArrayType(
+  elementType?: Matcher<t.TSType>,
+): Matcher<t.TSArrayType> {
+  return new TSArrayTypeMatcher(
+    elementType,
+  );
+}
+
+export class TSTupleTypeMatcher extends Matcher<t.TSTupleType> {
+  constructor(
+    private readonly elementTypes?: Matcher<Array<t.TSType>> | Array<Matcher<t.TSType>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTupleType {
+    if (
+      !isNode(node) ||
+      !t.isTSTupleType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.elementTypes === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.elementTypes)) {
+      if (!tupleOf<unknown>(...this.elementTypes).match(node.elementTypes)) {
+        return false;
+      }
+    } else if (!this.elementTypes.match(node.elementTypes)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTupleType(
+  elementTypes?: Matcher<Array<t.TSType>> | Array<Matcher<t.TSType>>,
+): Matcher<t.TSTupleType> {
+  return new TSTupleTypeMatcher(
+    elementTypes,
+  );
+}
+
+export class TSOptionalTypeMatcher extends Matcher<t.TSOptionalType> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSOptionalType {
+    if (
+      !isNode(node) ||
+      !t.isTSOptionalType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsOptionalType(
+  typeAnnotation?: Matcher<t.TSType>,
+): Matcher<t.TSOptionalType> {
+  return new TSOptionalTypeMatcher(
+    typeAnnotation,
+  );
+}
+
+export class TSRestTypeMatcher extends Matcher<t.TSRestType> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSRestType {
+    if (
+      !isNode(node) ||
+      !t.isTSRestType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsRestType(
+  typeAnnotation?: Matcher<t.TSType>,
+): Matcher<t.TSRestType> {
+  return new TSRestTypeMatcher(
+    typeAnnotation,
+  );
+}
+
+export class TSUnionTypeMatcher extends Matcher<t.TSUnionType> {
+  constructor(
+    private readonly types?: Matcher<Array<t.TSType>> | Array<Matcher<t.TSType>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSUnionType {
+    if (
+      !isNode(node) ||
+      !t.isTSUnionType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.types === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.types)) {
+      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+        return false;
+      }
+    } else if (!this.types.match(node.types)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsUnionType(
+  types?: Matcher<Array<t.TSType>> | Array<Matcher<t.TSType>>,
+): Matcher<t.TSUnionType> {
+  return new TSUnionTypeMatcher(
+    types,
+  );
+}
+
+export class TSIntersectionTypeMatcher extends Matcher<t.TSIntersectionType> {
+  constructor(
+    private readonly types?: Matcher<Array<t.TSType>> | Array<Matcher<t.TSType>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSIntersectionType {
+    if (
+      !isNode(node) ||
+      !t.isTSIntersectionType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.types === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.types)) {
+      if (!tupleOf<unknown>(...this.types).match(node.types)) {
+        return false;
+      }
+    } else if (!this.types.match(node.types)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsIntersectionType(
+  types?: Matcher<Array<t.TSType>> | Array<Matcher<t.TSType>>,
+): Matcher<t.TSIntersectionType> {
+  return new TSIntersectionTypeMatcher(
+    types,
+  );
+}
+
+export class TSConditionalTypeMatcher extends Matcher<t.TSConditionalType> {
+  constructor(
+    private readonly checkType?: Matcher<t.TSType>,
+    private readonly extendsType?: Matcher<t.TSType>,
+    private readonly trueType?: Matcher<t.TSType>,
+    private readonly falseType?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSConditionalType {
+    if (
+      !isNode(node) ||
+      !t.isTSConditionalType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.checkType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.checkType.match(node.checkType)) {
+      return false;
+    }
+
+    if (typeof this.extendsType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.extendsType.match(node.extendsType)) {
+      return false;
+    }
+
+    if (typeof this.trueType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.trueType.match(node.trueType)) {
+      return false;
+    }
+
+    if (typeof this.falseType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.falseType.match(node.falseType)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsConditionalType(
+  checkType?: Matcher<t.TSType>,
+  extendsType?: Matcher<t.TSType>,
+  trueType?: Matcher<t.TSType>,
+  falseType?: Matcher<t.TSType>,
+): Matcher<t.TSConditionalType> {
+  return new TSConditionalTypeMatcher(
+    checkType,
+    extendsType,
+    trueType,
+    falseType,
+  );
+}
+
+export class TSInferTypeMatcher extends Matcher<t.TSInferType> {
+  constructor(
+    private readonly typeParameter?: Matcher<t.TSTypeParameter>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSInferType {
+    if (
+      !isNode(node) ||
+      !t.isTSInferType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeParameter === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeParameter.match(node.typeParameter)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsInferType(
+  typeParameter?: Matcher<t.TSTypeParameter>,
+): Matcher<t.TSInferType> {
+  return new TSInferTypeMatcher(
+    typeParameter,
+  );
+}
+
+export class TSParenthesizedTypeMatcher extends Matcher<t.TSParenthesizedType> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSParenthesizedType {
+    if (
+      !isNode(node) ||
+      !t.isTSParenthesizedType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsParenthesizedType(
+  typeAnnotation?: Matcher<t.TSType>,
+): Matcher<t.TSParenthesizedType> {
+  return new TSParenthesizedTypeMatcher(
+    typeAnnotation,
+  );
+}
+
+export class TSTypeOperatorMatcher extends Matcher<t.TSTypeOperator> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeOperator {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeOperator(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeOperator(
+  typeAnnotation?: Matcher<t.TSType>,
+): Matcher<t.TSTypeOperator> {
+  return new TSTypeOperatorMatcher(
+    typeAnnotation,
+  );
+}
+
+export class TSIndexedAccessTypeMatcher extends Matcher<t.TSIndexedAccessType> {
+  constructor(
+    private readonly objectType?: Matcher<t.TSType>,
+    private readonly indexType?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSIndexedAccessType {
+    if (
+      !isNode(node) ||
+      !t.isTSIndexedAccessType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.objectType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.objectType.match(node.objectType)) {
+      return false;
+    }
+
+    if (typeof this.indexType === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.indexType.match(node.indexType)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsIndexedAccessType(
+  objectType?: Matcher<t.TSType>,
+  indexType?: Matcher<t.TSType>,
+): Matcher<t.TSIndexedAccessType> {
+  return new TSIndexedAccessTypeMatcher(
+    objectType,
+    indexType,
+  );
+}
+
+export class TSMappedTypeMatcher extends Matcher<t.TSMappedType> {
+  constructor(
+    private readonly typeParameter?: Matcher<t.TSTypeParameter>,
+    private readonly typeAnnotation?: Matcher<t.TSType> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSMappedType {
+    if (
+      !isNode(node) ||
+      !t.isTSMappedType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeParameter === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeParameter.match(node.typeParameter)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeAnnotation === null) {
+      // null matcher means we expect null value
+      if (node.typeAnnotation !== null) {
+        return false;
+      }
+    } else if (node.typeAnnotation === null) {
+      return false;
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsMappedType(
+  typeParameter?: Matcher<t.TSTypeParameter>,
+  typeAnnotation?: Matcher<t.TSType> | null,
+): Matcher<t.TSMappedType> {
+  return new TSMappedTypeMatcher(
+    typeParameter,
+    typeAnnotation,
+  );
+}
+
+export class TSLiteralTypeMatcher extends Matcher<t.TSLiteralType> {
+  constructor(
+    private readonly literal?: Matcher<t.NumericLiteral | t.StringLiteral | t.BooleanLiteral>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSLiteralType {
+    if (
+      !isNode(node) ||
+      !t.isTSLiteralType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.literal === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.literal.match(node.literal)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsLiteralType(
+  literal?: Matcher<t.NumericLiteral | t.StringLiteral | t.BooleanLiteral>,
+): Matcher<t.TSLiteralType> {
+  return new TSLiteralTypeMatcher(
+    literal,
+  );
+}
+
+export class TSExpressionWithTypeArgumentsMatcher extends Matcher<t.TSExpressionWithTypeArguments> {
+  constructor(
+    private readonly expression?: Matcher<t.TSEntityName>,
+    private readonly typeParameters?: Matcher<t.TSTypeParameterInstantiation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSExpressionWithTypeArguments {
+    if (
+      !isNode(node) ||
+      !t.isTSExpressionWithTypeArguments(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsExpressionWithTypeArguments(
+  expression?: Matcher<t.TSEntityName>,
+  typeParameters?: Matcher<t.TSTypeParameterInstantiation> | null,
+): Matcher<t.TSExpressionWithTypeArguments> {
+  return new TSExpressionWithTypeArgumentsMatcher(
+    expression,
+    typeParameters,
+  );
+}
+
+export class TSInterfaceDeclarationMatcher extends Matcher<t.TSInterfaceDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+    private readonly _extends?: Matcher<Array<t.TSExpressionWithTypeArguments>> | Array<Matcher<t.TSExpressionWithTypeArguments>> | null,
+    private readonly body?: Matcher<t.TSInterfaceBody>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSInterfaceDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSInterfaceDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this._extends === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this._extends === null) {
+      // null matcher means we expect null value
+      if (node.extends !== null) {
+        return false;
+      }
+    } else if (node.extends === null) {
+      return false;
+    } else if (Array.isArray(this._extends)) {
+      if (!tupleOf<unknown>(...this._extends).match(node.extends)) {
+        return false;
+      }
+    } else if (!this._extends.match(node.extends)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsInterfaceDeclaration(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+  _extends?: Matcher<Array<t.TSExpressionWithTypeArguments>> | Array<Matcher<t.TSExpressionWithTypeArguments>> | null,
+  body?: Matcher<t.TSInterfaceBody>,
+): Matcher<t.TSInterfaceDeclaration> {
+  return new TSInterfaceDeclarationMatcher(
+    id,
+    typeParameters,
+    _extends,
+    body,
+  );
+}
+
+export class TSInterfaceBodyMatcher extends Matcher<t.TSInterfaceBody> {
+  constructor(
+    private readonly body?: Matcher<Array<t.TSTypeElement>> | Array<Matcher<t.TSTypeElement>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSInterfaceBody {
+    if (
+      !isNode(node) ||
+      !t.isTSInterfaceBody(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.body)) {
+      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+        return false;
+      }
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsInterfaceBody(
+  body?: Matcher<Array<t.TSTypeElement>> | Array<Matcher<t.TSTypeElement>>,
+): Matcher<t.TSInterfaceBody> {
+  return new TSInterfaceBodyMatcher(
+    body,
+  );
+}
+
+export class TSTypeAliasDeclarationMatcher extends Matcher<t.TSTypeAliasDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+    private readonly typeAnnotation?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeAliasDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeAliasDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeAliasDeclaration(
+  id?: Matcher<t.Identifier>,
+  typeParameters?: Matcher<t.TSTypeParameterDeclaration> | null,
+  typeAnnotation?: Matcher<t.TSType>,
+): Matcher<t.TSTypeAliasDeclaration> {
+  return new TSTypeAliasDeclarationMatcher(
+    id,
+    typeParameters,
+    typeAnnotation,
+  );
+}
+
+export class TSAsExpressionMatcher extends Matcher<t.TSAsExpression> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+    private readonly typeAnnotation?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSAsExpression {
+    if (
+      !isNode(node) ||
+      !t.isTSAsExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsAsExpression(
+  expression?: Matcher<t.Expression>,
+  typeAnnotation?: Matcher<t.TSType>,
+): Matcher<t.TSAsExpression> {
+  return new TSAsExpressionMatcher(
+    expression,
+    typeAnnotation,
+  );
+}
+
+export class TSTypeAssertionMatcher extends Matcher<t.TSTypeAssertion> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.TSType>,
+    private readonly expression?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeAssertion {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeAssertion(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeAssertion(
+  typeAnnotation?: Matcher<t.TSType>,
+  expression?: Matcher<t.Expression>,
+): Matcher<t.TSTypeAssertion> {
+  return new TSTypeAssertionMatcher(
+    typeAnnotation,
+    expression,
+  );
+}
+
+export class TSEnumDeclarationMatcher extends Matcher<t.TSEnumDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly members?: Matcher<Array<t.TSEnumMember>> | Array<Matcher<t.TSEnumMember>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSEnumDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSEnumDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.members === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.members)) {
+      if (!tupleOf<unknown>(...this.members).match(node.members)) {
+        return false;
+      }
+    } else if (!this.members.match(node.members)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsEnumDeclaration(
+  id?: Matcher<t.Identifier>,
+  members?: Matcher<Array<t.TSEnumMember>> | Array<Matcher<t.TSEnumMember>>,
+): Matcher<t.TSEnumDeclaration> {
+  return new TSEnumDeclarationMatcher(
+    id,
+    members,
+  );
+}
+
+export class TSEnumMemberMatcher extends Matcher<t.TSEnumMember> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier | t.StringLiteral>,
+    private readonly initializer?: Matcher<t.Expression> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSEnumMember {
+    if (
+      !isNode(node) ||
+      !t.isTSEnumMember(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.initializer === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.initializer === null) {
+      // null matcher means we expect null value
+      if (node.initializer !== null) {
+        return false;
+      }
+    } else if (node.initializer === null) {
+      return false;
+    } else if (!this.initializer.match(node.initializer)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsEnumMember(
+  id?: Matcher<t.Identifier | t.StringLiteral>,
+  initializer?: Matcher<t.Expression> | null,
+): Matcher<t.TSEnumMember> {
+  return new TSEnumMemberMatcher(
+    id,
+    initializer,
+  );
+}
+
+export class TSModuleDeclarationMatcher extends Matcher<t.TSModuleDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier | t.StringLiteral>,
+    private readonly body?: Matcher<t.TSModuleBlock | t.TSModuleDeclaration>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSModuleDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSModuleDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsModuleDeclaration(
+  id?: Matcher<t.Identifier | t.StringLiteral>,
+  body?: Matcher<t.TSModuleBlock | t.TSModuleDeclaration>,
+): Matcher<t.TSModuleDeclaration> {
+  return new TSModuleDeclarationMatcher(
+    id,
+    body,
+  );
+}
+
+export class TSModuleBlockMatcher extends Matcher<t.TSModuleBlock> {
+  constructor(
+    private readonly body?: Matcher<Array<t.Statement>> | Array<Matcher<t.Statement>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSModuleBlock {
+    if (
+      !isNode(node) ||
+      !t.isTSModuleBlock(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.body === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.body)) {
+      if (!tupleOf<unknown>(...this.body).match(node.body)) {
+        return false;
+      }
+    } else if (!this.body.match(node.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsModuleBlock(
+  body?: Matcher<Array<t.Statement>> | Array<Matcher<t.Statement>>,
+): Matcher<t.TSModuleBlock> {
+  return new TSModuleBlockMatcher(
+    body,
+  );
+}
+
+export class TSImportTypeMatcher extends Matcher<t.TSImportType> {
+  constructor(
+    private readonly argument?: Matcher<t.StringLiteral>,
+    private readonly qualifier?: Matcher<t.TSEntityName> | null,
+    private readonly typeParameters?: Matcher<t.TSTypeParameterInstantiation> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSImportType {
+    if (
+      !isNode(node) ||
+      !t.isTSImportType(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.argument === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.argument.match(node.argument)) {
+      return false;
+    }
+
+    if (typeof this.qualifier === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.qualifier === null) {
+      // null matcher means we expect null value
+      if (node.qualifier !== null) {
+        return false;
+      }
+    } else if (node.qualifier === null) {
+      return false;
+    } else if (!this.qualifier.match(node.qualifier)) {
+      return false;
+    }
+
+    if (typeof this.typeParameters === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.typeParameters === null) {
+      // null matcher means we expect null value
+      if (node.typeParameters !== null) {
+        return false;
+      }
+    } else if (node.typeParameters === null) {
+      return false;
+    } else if (!this.typeParameters.match(node.typeParameters)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsImportType(
+  argument?: Matcher<t.StringLiteral>,
+  qualifier?: Matcher<t.TSEntityName> | null,
+  typeParameters?: Matcher<t.TSTypeParameterInstantiation> | null,
+): Matcher<t.TSImportType> {
+  return new TSImportTypeMatcher(
+    argument,
+    qualifier,
+    typeParameters,
+  );
+}
+
+export class TSImportEqualsDeclarationMatcher extends Matcher<t.TSImportEqualsDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+    private readonly moduleReference?: Matcher<t.TSEntityName | t.TSExternalModuleReference>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSImportEqualsDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSImportEqualsDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    if (typeof this.moduleReference === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.moduleReference.match(node.moduleReference)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsImportEqualsDeclaration(
+  id?: Matcher<t.Identifier>,
+  moduleReference?: Matcher<t.TSEntityName | t.TSExternalModuleReference>,
+): Matcher<t.TSImportEqualsDeclaration> {
+  return new TSImportEqualsDeclarationMatcher(
+    id,
+    moduleReference,
+  );
+}
+
+export class TSExternalModuleReferenceMatcher extends Matcher<t.TSExternalModuleReference> {
+  constructor(
+    private readonly expression?: Matcher<t.StringLiteral>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSExternalModuleReference {
+    if (
+      !isNode(node) ||
+      !t.isTSExternalModuleReference(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsExternalModuleReference(
+  expression?: Matcher<t.StringLiteral>,
+): Matcher<t.TSExternalModuleReference> {
+  return new TSExternalModuleReferenceMatcher(
+    expression,
+  );
+}
+
+export class TSNonNullExpressionMatcher extends Matcher<t.TSNonNullExpression> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSNonNullExpression {
+    if (
+      !isNode(node) ||
+      !t.isTSNonNullExpression(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsNonNullExpression(
+  expression?: Matcher<t.Expression>,
+): Matcher<t.TSNonNullExpression> {
+  return new TSNonNullExpressionMatcher(
+    expression,
+  );
+}
+
+export class TSExportAssignmentMatcher extends Matcher<t.TSExportAssignment> {
+  constructor(
+    private readonly expression?: Matcher<t.Expression>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSExportAssignment {
+    if (
+      !isNode(node) ||
+      !t.isTSExportAssignment(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.expression === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.expression.match(node.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsExportAssignment(
+  expression?: Matcher<t.Expression>,
+): Matcher<t.TSExportAssignment> {
+  return new TSExportAssignmentMatcher(
+    expression,
+  );
+}
+
+export class TSNamespaceExportDeclarationMatcher extends Matcher<t.TSNamespaceExportDeclaration> {
+  constructor(
+    private readonly id?: Matcher<t.Identifier>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSNamespaceExportDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSNamespaceExportDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.id === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.id.match(node.id)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsNamespaceExportDeclaration(
+  id?: Matcher<t.Identifier>,
+): Matcher<t.TSNamespaceExportDeclaration> {
+  return new TSNamespaceExportDeclarationMatcher(
+    id,
+  );
+}
+
+export class TSTypeAnnotationMatcher extends Matcher<t.TSTypeAnnotation> {
+  constructor(
+    private readonly typeAnnotation?: Matcher<t.TSType>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeAnnotation {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeAnnotation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.typeAnnotation === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (!this.typeAnnotation.match(node.typeAnnotation)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeAnnotation(
+  typeAnnotation?: Matcher<t.TSType>,
+): Matcher<t.TSTypeAnnotation> {
+  return new TSTypeAnnotationMatcher(
+    typeAnnotation,
+  );
+}
+
+export class TSTypeParameterInstantiationMatcher extends Matcher<t.TSTypeParameterInstantiation> {
+  constructor(
+    private readonly params?: Matcher<Array<t.TSType>> | Array<Matcher<t.TSType>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeParameterInstantiation {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeParameterInstantiation(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeParameterInstantiation(
+  params?: Matcher<Array<t.TSType>> | Array<Matcher<t.TSType>>,
+): Matcher<t.TSTypeParameterInstantiation> {
+  return new TSTypeParameterInstantiationMatcher(
+    params,
+  );
+}
+
+export class TSTypeParameterDeclarationMatcher extends Matcher<t.TSTypeParameterDeclaration> {
+  constructor(
+    private readonly params?: Matcher<Array<t.TSTypeParameter>> | Array<Matcher<t.TSTypeParameter>>,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeParameterDeclaration {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeParameterDeclaration(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.params === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (Array.isArray(this.params)) {
+      if (!tupleOf<unknown>(...this.params).match(node.params)) {
+        return false;
+      }
+    } else if (!this.params.match(node.params)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeParameterDeclaration(
+  params?: Matcher<Array<t.TSTypeParameter>> | Array<Matcher<t.TSTypeParameter>>,
+): Matcher<t.TSTypeParameterDeclaration> {
+  return new TSTypeParameterDeclarationMatcher(
+    params,
+  );
+}
+
+export class TSTypeParameterMatcher extends Matcher<t.TSTypeParameter> {
+  constructor(
+    private readonly constraint?: Matcher<t.TSType> | null,
+    private readonly _default?: Matcher<t.TSType> | null,
+  ) {
+    super();
+  }
+
+  match(node: unknown): node is t.TSTypeParameter {
+    if (
+      !isNode(node) ||
+      !t.isTSTypeParameter(node)
+    ) {
+      return false;
+    }
+
+    if (typeof this.constraint === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this.constraint === null) {
+      // null matcher means we expect null value
+      if (node.constraint !== null) {
+        return false;
+      }
+    } else if (node.constraint === null) {
+      return false;
+    } else if (!this.constraint.match(node.constraint)) {
+      return false;
+    }
+
+    if (typeof this._default === 'undefined') {
+      // undefined matcher means anything matches
+    } else if (this._default === null) {
+      // null matcher means we expect null value
+      if (node.default !== null) {
+        return false;
+      }
+    } else if (node.default === null) {
+      return false;
+    } else if (!this._default.match(node.default)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export function tsTypeParameter(
+  constraint?: Matcher<t.TSType> | null,
+  _default?: Matcher<t.TSType> | null,
+): Matcher<t.TSTypeParameter> {
+  return new TSTypeParameterMatcher(
+    constraint,
+    _default,
+  );
+}
+

--- a/packages/matchers/src/matchers/Function.ts
+++ b/packages/matchers/src/matchers/Function.ts
@@ -11,22 +11,27 @@ export class FunctionMatcher extends Matcher<t.Function> {
     super();
   }
 
-  match(value: unknown): value is t.Function {
+  matchValue(
+    value: unknown,
+    keys: ReadonlyArray<PropertyKey>
+  ): value is t.Function {
     if (!isNode(value) || !t.isFunction(value)) {
       return false;
     }
 
     if (this.params) {
       if (Array.isArray(this.params)) {
-        if (!tupleOf(...this.params).match(value.params)) {
+        if (
+          !tupleOf(...this.params).matchValue(value.params, [...keys, 'params'])
+        ) {
           return false;
         }
-      } else if (!this.params.match(value.params)) {
+      } else if (!this.params.matchValue(value.params, [...keys, 'params'])) {
         return false;
       }
     }
 
-    if (this.body && !this.body.match(value.body)) {
+    if (this.body && !this.body.matchValue(value.body, [...keys, 'body'])) {
       return false;
     }
 

--- a/packages/matchers/src/matchers/Function.ts
+++ b/packages/matchers/src/matchers/Function.ts
@@ -1,0 +1,42 @@
+import * as t from '@babel/types';
+import tupleOf from './tupleOf';
+import { isNode } from '../NodeTypes';
+import Matcher from './Matcher';
+
+export class FunctionMatcher extends Matcher<t.Function> {
+  constructor(
+    private readonly params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+    private readonly body?: Matcher<t.Expression | t.BlockStatement>
+  ) {
+    super();
+  }
+
+  match(value: unknown): value is t.Function {
+    if (!isNode(value) || !t.isFunction(value)) {
+      return false;
+    }
+
+    if (this.params) {
+      if (Array.isArray(this.params)) {
+        if (!tupleOf(...this.params).match(value.params)) {
+          return false;
+        }
+      } else if (!this.params.match(value.params)) {
+        return false;
+      }
+    }
+
+    if (this.body && !this.body.match(value.body)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export default function Function(
+  params?: Matcher<Array<t.LVal>> | Array<Matcher<t.LVal>>,
+  body?: Matcher<t.Expression | t.BlockStatement>
+): Matcher<t.Function> {
+  return new FunctionMatcher(params, body);
+}

--- a/packages/matchers/src/matchers/Matcher.ts
+++ b/packages/matchers/src/matchers/Matcher.ts
@@ -1,0 +1,6 @@
+export default class Matcher<T> {
+  // eslint-disable-next-line typescript/no-unused-vars
+  match(value: unknown): value is T {
+    throw new Error(`${this.constructor.name}#match is not implemented`);
+  }
+}

--- a/packages/matchers/src/matchers/Matcher.ts
+++ b/packages/matchers/src/matchers/Matcher.ts
@@ -1,6 +1,14 @@
 export default class Matcher<T> {
-  // eslint-disable-next-line typescript/no-unused-vars
-  match(value: unknown): value is T {
-    throw new Error(`${this.constructor.name}#match is not implemented`);
+  match(value: unknown, keys: ReadonlyArray<PropertyKey> = []): value is T {
+    return this.matchValue(value, keys);
+  }
+
+  matchValue(
+    /* eslint-disable typescript/no-unused-vars */
+    value: unknown,
+    keys: ReadonlyArray<PropertyKey>
+    /* eslint-enable typescript/no-unused-vars */
+  ): value is T {
+    throw new Error(`${this.constructor.name}#matchValue is not implemented`);
   }
 }

--- a/packages/matchers/src/matchers/anyExpression.ts
+++ b/packages/matchers/src/matchers/anyExpression.ts
@@ -3,7 +3,7 @@ import * as t from '@babel/types';
 import Matcher from './Matcher';
 
 export class AnyExpressionMatcher extends Matcher<t.Expression> {
-  match(value: unknown): value is t.Expression {
+  matchValue(value: unknown): value is t.Expression {
     return isNode(value) && t.isExpression(value);
   }
 }

--- a/packages/matchers/src/matchers/anyExpression.ts
+++ b/packages/matchers/src/matchers/anyExpression.ts
@@ -1,0 +1,13 @@
+import { isNode } from '../NodeTypes';
+import * as t from '@babel/types';
+import Matcher from './Matcher';
+
+export class AnyExpressionMatcher extends Matcher<t.Expression> {
+  match(value: unknown): value is t.Expression {
+    return isNode(value) && t.isExpression(value);
+  }
+}
+
+export default function anyExpression(): Matcher<t.Expression> {
+  return new AnyExpressionMatcher();
+}

--- a/packages/matchers/src/matchers/anyList.ts
+++ b/packages/matchers/src/matchers/anyList.ts
@@ -1,0 +1,71 @@
+import { Spacer } from '../matchers';
+import distributeAcrossSpacers from '../utils/distributeAcrossSpacers';
+import Matcher from './Matcher';
+
+export class AnyListMatcher<T> extends Matcher<Array<T>> {
+  private readonly spacers: Array<Spacer> = [];
+
+  constructor(private readonly elements: Array<Matcher<T> | Spacer>) {
+    super();
+
+    for (const element of elements) {
+      if (element instanceof Spacer) {
+        this.spacers.push(element);
+      }
+    }
+  }
+
+  match(array: unknown): array is Array<T> {
+    if (!Array.isArray(array)) {
+      return false;
+    }
+
+    if (this.elements.length === 0 && array.length === 0) {
+      return true;
+    }
+
+    const spacerAllocations = distributeAcrossSpacers(
+      this.spacers,
+      array.length - this.elements.length + this.spacers.length
+    );
+
+    for (const allocations of spacerAllocations) {
+      const toMatch: Array<T> = array.slice();
+      let matchedAll = true;
+
+      for (const element of this.elements) {
+        if (element instanceof Spacer) {
+          let spacesForSpacer = allocations.shift() || 0;
+
+          while (spacesForSpacer > 0) {
+            toMatch.shift();
+            spacesForSpacer--;
+          }
+        } else if (!element.match(toMatch.shift())) {
+          matchedAll = false;
+          break;
+        }
+      }
+
+      if (matchedAll) {
+        if (toMatch.length > 0) {
+          throw new Error(
+            `expected to consume all elements to match but ${
+              toMatch.length
+            } remain!`
+          );
+        }
+
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+
+export default function anyList<T>(
+  ...elements: Array<Matcher<T> | Spacer>
+): Matcher<Array<T>> {
+  return new AnyListMatcher(elements);
+}

--- a/packages/matchers/src/matchers/anyList.ts
+++ b/packages/matchers/src/matchers/anyList.ts
@@ -15,7 +15,10 @@ export class AnyListMatcher<T> extends Matcher<Array<T>> {
     }
   }
 
-  match(array: unknown): array is Array<T> {
+  matchValue(
+    array: unknown,
+    keys: ReadonlyArray<PropertyKey>
+  ): array is Array<T> {
     if (!Array.isArray(array)) {
       return false;
     }
@@ -32,6 +35,7 @@ export class AnyListMatcher<T> extends Matcher<Array<T>> {
     for (const allocations of spacerAllocations) {
       const toMatch: Array<T> = array.slice();
       let matchedAll = true;
+      let key = 0;
 
       for (const element of this.elements) {
         if (element instanceof Spacer) {
@@ -40,10 +44,13 @@ export class AnyListMatcher<T> extends Matcher<Array<T>> {
           while (spacesForSpacer > 0) {
             toMatch.shift();
             spacesForSpacer--;
+            key++;
           }
-        } else if (!element.match(toMatch.shift())) {
+        } else if (!element.matchValue(toMatch.shift(), [...keys, key])) {
           matchedAll = false;
           break;
+        } else {
+          key++;
         }
       }
 

--- a/packages/matchers/src/matchers/anyNode.ts
+++ b/packages/matchers/src/matchers/anyNode.ts
@@ -1,0 +1,13 @@
+import * as t from '@babel/types';
+import { isNode } from '../NodeTypes';
+import Matcher from './Matcher';
+
+export class AnyNodeMatcher extends Matcher<t.Node> {
+  match(value: unknown): value is t.Node {
+    return isNode(value);
+  }
+}
+
+export default function anyNode(): Matcher<t.Node> {
+  return new AnyNodeMatcher();
+}

--- a/packages/matchers/src/matchers/anyNode.ts
+++ b/packages/matchers/src/matchers/anyNode.ts
@@ -3,7 +3,7 @@ import { isNode } from '../NodeTypes';
 import Matcher from './Matcher';
 
 export class AnyNodeMatcher extends Matcher<t.Node> {
-  match(value: unknown): value is t.Node {
+  matchValue(value: unknown): value is t.Node {
     return isNode(value);
   }
 }

--- a/packages/matchers/src/matchers/anyNumber.ts
+++ b/packages/matchers/src/matchers/anyNumber.ts
@@ -1,0 +1,11 @@
+import Matcher from './Matcher';
+
+export class NumberMatcher extends Matcher<number> {
+  match(value: unknown): value is number {
+    return typeof value === 'number' || value instanceof Number;
+  }
+}
+
+export default function anyNumber(): Matcher<number> {
+  return new NumberMatcher();
+}

--- a/packages/matchers/src/matchers/anyNumber.ts
+++ b/packages/matchers/src/matchers/anyNumber.ts
@@ -1,7 +1,7 @@
 import Matcher from './Matcher';
 
 export class NumberMatcher extends Matcher<number> {
-  match(value: unknown): value is number {
+  matchValue(value: unknown): value is number {
     return typeof value === 'number' || value instanceof Number;
   }
 }

--- a/packages/matchers/src/matchers/anyStatement.ts
+++ b/packages/matchers/src/matchers/anyStatement.ts
@@ -1,0 +1,13 @@
+import * as t from '@babel/types';
+import { isNode } from '../NodeTypes';
+import Matcher from './Matcher';
+
+export class AnyStatementMatcher extends Matcher<t.Statement> {
+  match(value: unknown): value is t.Statement {
+    return isNode(value) && t.isStatement(value);
+  }
+}
+
+export default function anyStatement(): Matcher<t.Statement> {
+  return new AnyStatementMatcher();
+}

--- a/packages/matchers/src/matchers/anyStatement.ts
+++ b/packages/matchers/src/matchers/anyStatement.ts
@@ -3,7 +3,7 @@ import { isNode } from '../NodeTypes';
 import Matcher from './Matcher';
 
 export class AnyStatementMatcher extends Matcher<t.Statement> {
-  match(value: unknown): value is t.Statement {
+  matchValue(value: unknown): value is t.Statement {
     return isNode(value) && t.isStatement(value);
   }
 }

--- a/packages/matchers/src/matchers/anyString.ts
+++ b/packages/matchers/src/matchers/anyString.ts
@@ -1,7 +1,7 @@
 import Matcher from './Matcher';
 
 export class StringMatcher extends Matcher<string> {
-  match(value: unknown): value is string {
+  matchValue(value: unknown): value is string {
     return typeof value === 'string' || value instanceof String;
   }
 }

--- a/packages/matchers/src/matchers/anyString.ts
+++ b/packages/matchers/src/matchers/anyString.ts
@@ -1,0 +1,11 @@
+import Matcher from './Matcher';
+
+export class StringMatcher extends Matcher<string> {
+  match(value: unknown): value is string {
+    return typeof value === 'string' || value instanceof String;
+  }
+}
+
+export default function anyString(): Matcher<string> {
+  return new StringMatcher();
+}

--- a/packages/matchers/src/matchers/anything.ts
+++ b/packages/matchers/src/matchers/anything.ts
@@ -1,0 +1,12 @@
+import Matcher from './Matcher';
+
+export class AnythingMatcher<T> extends Matcher<T> {
+  // eslint-disable-next-line typescript/no-unused-vars
+  match(value: unknown): value is T {
+    return true;
+  }
+}
+
+export default function anything<T>(): Matcher<T> {
+  return new AnythingMatcher();
+}

--- a/packages/matchers/src/matchers/anything.ts
+++ b/packages/matchers/src/matchers/anything.ts
@@ -2,7 +2,7 @@ import Matcher from './Matcher';
 
 export class AnythingMatcher<T> extends Matcher<T> {
   // eslint-disable-next-line typescript/no-unused-vars
-  match(value: unknown): value is T {
+  matchValue(value: unknown): value is T {
     return true;
   }
 }

--- a/packages/matchers/src/matchers/arrayOf.ts
+++ b/packages/matchers/src/matchers/arrayOf.ts
@@ -1,0 +1,27 @@
+import Matcher from './Matcher';
+
+export class ArrayOfMatcher<T> extends Matcher<Array<T>> {
+  constructor(private readonly elementMatcher: Matcher<T>) {
+    super();
+  }
+
+  match(value: unknown): value is Array<T> {
+    if (!Array.isArray(value)) {
+      return false;
+    }
+
+    for (const element of value) {
+      if (!this.elementMatcher.match(element)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+export default function arrayOf<T>(
+  elementMatcher: Matcher<T>
+): Matcher<Array<T>> {
+  return new ArrayOfMatcher(elementMatcher);
+}

--- a/packages/matchers/src/matchers/arrayOf.ts
+++ b/packages/matchers/src/matchers/arrayOf.ts
@@ -5,13 +5,16 @@ export class ArrayOfMatcher<T> extends Matcher<Array<T>> {
     super();
   }
 
-  match(value: unknown): value is Array<T> {
+  matchValue(
+    value: unknown,
+    keys: ReadonlyArray<PropertyKey>
+  ): value is Array<T> {
     if (!Array.isArray(value)) {
       return false;
     }
 
-    for (const element of value) {
-      if (!this.elementMatcher.match(element)) {
+    for (const [i, element] of value.entries()) {
+      if (!this.elementMatcher.matchValue(element, [...keys, i])) {
         return false;
       }
     }

--- a/packages/matchers/src/matchers/capture.ts
+++ b/packages/matchers/src/matchers/capture.ts
@@ -1,15 +1,15 @@
 import { anything } from '../matchers';
 import Matcher from './Matcher';
 
-export class CapturedMatcher<T> extends Matcher<T> {
-  private _current?: T;
+export class CapturedMatcher<C, M = C> extends Matcher<M> {
+  private _current?: C;
   private _currentKeys?: ReadonlyArray<PropertyKey>;
 
-  constructor(private readonly matcher: Matcher<T> = anything()) {
+  constructor(private readonly matcher: Matcher<C> = anything()) {
     super();
   }
 
-  get current(): T | undefined {
+  get current(): C | undefined {
     return this._current;
   }
 
@@ -17,21 +17,23 @@ export class CapturedMatcher<T> extends Matcher<T> {
     return this._currentKeys;
   }
 
-  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is T {
+  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is M {
     if (this.matcher.matchValue(value, keys)) {
-      this.capture(value, keys);
+      this.capture((value as unknown) as C, keys);
       return true;
     } else {
       return false;
     }
   }
 
-  protected capture(value: T, keys: ReadonlyArray<PropertyKey>): void {
+  protected capture(value: C, keys: ReadonlyArray<PropertyKey>): void {
     this._current = value;
     this._currentKeys = keys;
   }
 }
 
-export default function capture<T>(matcher?: Matcher<T>): CapturedMatcher<T> {
+export default function capture<C, M = C>(
+  matcher?: Matcher<C>
+): CapturedMatcher<C, M> {
   return new CapturedMatcher(matcher);
 }

--- a/packages/matchers/src/matchers/capture.ts
+++ b/packages/matchers/src/matchers/capture.ts
@@ -1,0 +1,31 @@
+import { anything } from '../matchers';
+import Matcher from './Matcher';
+
+export class CapturedMatcher<T> extends Matcher<T> {
+  private _current: T | undefined;
+
+  constructor(private readonly matcher: Matcher<T> = anything()) {
+    super();
+  }
+
+  get current(): T | undefined {
+    return this._current;
+  }
+
+  match(value: unknown): value is T {
+    if (this.matcher.match(value)) {
+      this.capture(value);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  protected capture(value: T): void {
+    this._current = value;
+  }
+}
+
+export default function capture<T>(matcher?: Matcher<T>): CapturedMatcher<T> {
+  return new CapturedMatcher(matcher);
+}

--- a/packages/matchers/src/matchers/capture.ts
+++ b/packages/matchers/src/matchers/capture.ts
@@ -2,7 +2,8 @@ import { anything } from '../matchers';
 import Matcher from './Matcher';
 
 export class CapturedMatcher<T> extends Matcher<T> {
-  private _current: T | undefined;
+  private _current?: T;
+  private _currentKeys?: ReadonlyArray<PropertyKey>;
 
   constructor(private readonly matcher: Matcher<T> = anything()) {
     super();
@@ -12,17 +13,22 @@ export class CapturedMatcher<T> extends Matcher<T> {
     return this._current;
   }
 
-  match(value: unknown): value is T {
-    if (this.matcher.match(value)) {
-      this.capture(value);
+  get currentKeys(): ReadonlyArray<PropertyKey> | undefined {
+    return this._currentKeys;
+  }
+
+  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is T {
+    if (this.matcher.matchValue(value, keys)) {
+      this.capture(value, keys);
       return true;
     } else {
       return false;
     }
   }
 
-  protected capture(value: T): void {
+  protected capture(value: T, keys: ReadonlyArray<PropertyKey>): void {
     this._current = value;
+    this._currentKeys = keys;
   }
 }
 

--- a/packages/matchers/src/matchers/containerOf.ts
+++ b/packages/matchers/src/matchers/containerOf.ts
@@ -13,25 +13,25 @@ export class ContainerOfMatcher<T extends t.Node> extends CapturedMatcher<T> {
     super();
   }
 
-  match(value: unknown): value is T {
+  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is T {
     if (!isNode(value)) {
       return false;
     }
 
-    if (this.containedMatcher.match(value)) {
-      this.capture(value);
+    if (this.containedMatcher.matchValue(value, keys)) {
+      this.capture(value, keys);
       return true;
     }
 
     for (const key in value) {
       const valueAtKey = value[key as keyof typeof value];
       if (Array.isArray(valueAtKey)) {
-        for (const element of valueAtKey) {
-          if (this.match(element)) {
+        for (const [i, element] of valueAtKey.entries()) {
+          if (this.matchValue(element, [...keys, key, i])) {
             return true;
           }
         }
-      } else if (this.match(valueAtKey)) {
+      } else if (this.matchValue(valueAtKey, [...keys, key])) {
         return true;
       }
     }

--- a/packages/matchers/src/matchers/containerOf.ts
+++ b/packages/matchers/src/matchers/containerOf.ts
@@ -8,12 +8,15 @@ import { isNode } from '../NodeTypes';
  * descendants of a given node. The matched descendant is captured as the
  * current value of this capturing matcher.
  */
-export class ContainerOfMatcher<T extends t.Node> extends CapturedMatcher<T> {
-  constructor(private readonly containedMatcher: Matcher<T>) {
+export class ContainerOfMatcher<
+  C extends t.Node,
+  M extends t.Node = C
+> extends CapturedMatcher<C, M> {
+  constructor(private readonly containedMatcher: Matcher<C>) {
     super();
   }
 
-  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is T {
+  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is M {
     if (!isNode(value)) {
       return false;
     }
@@ -40,8 +43,8 @@ export class ContainerOfMatcher<T extends t.Node> extends CapturedMatcher<T> {
   }
 }
 
-export default function containerOf<T extends t.Node>(
-  containedMatcher: Matcher<T>
-): CapturedMatcher<T> {
+export default function containerOf<C extends t.Node, M extends t.Node = C>(
+  containedMatcher: Matcher<C>
+): ContainerOfMatcher<C, M> {
   return new ContainerOfMatcher(containedMatcher);
 }

--- a/packages/matchers/src/matchers/containerOf.ts
+++ b/packages/matchers/src/matchers/containerOf.ts
@@ -1,0 +1,47 @@
+import * as t from '@babel/types';
+import { Matcher } from '../matchers';
+import { CapturedMatcher } from './capture';
+import { isNode } from '../NodeTypes';
+
+/**
+ * Matches and captures using another matcher by recursively checking all
+ * descendants of a given node. The matched descendant is captured as the
+ * current value of this capturing matcher.
+ */
+export class ContainerOfMatcher<T extends t.Node> extends CapturedMatcher<T> {
+  constructor(private readonly containedMatcher: Matcher<T>) {
+    super();
+  }
+
+  match(value: unknown): value is T {
+    if (!isNode(value)) {
+      return false;
+    }
+
+    if (this.containedMatcher.match(value)) {
+      this.capture(value);
+      return true;
+    }
+
+    for (const key in value) {
+      const valueAtKey = value[key as keyof typeof value];
+      if (Array.isArray(valueAtKey)) {
+        for (const element of valueAtKey) {
+          if (this.match(element)) {
+            return true;
+          }
+        }
+      } else if (this.match(valueAtKey)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+
+export default function containerOf<T extends t.Node>(
+  containedMatcher: Matcher<T>
+): CapturedMatcher<T> {
+  return new ContainerOfMatcher(containedMatcher);
+}

--- a/packages/matchers/src/matchers/fromCapture.ts
+++ b/packages/matchers/src/matchers/fromCapture.ts
@@ -1,0 +1,18 @@
+import { CapturedMatcher } from '../matchers';
+import Matcher from './Matcher';
+
+export class FromCaptureMatcher<T> extends Matcher<T> {
+  constructor(private readonly capturedMatcher: CapturedMatcher<T>) {
+    super();
+  }
+
+  match(value: unknown): value is T {
+    return this.capturedMatcher.current === value;
+  }
+}
+
+export default function fromCapture<T>(
+  capturedMatcher: CapturedMatcher<T>
+): Matcher<T> {
+  return new FromCaptureMatcher(capturedMatcher);
+}

--- a/packages/matchers/src/matchers/fromCapture.ts
+++ b/packages/matchers/src/matchers/fromCapture.ts
@@ -6,7 +6,7 @@ export class FromCaptureMatcher<T> extends Matcher<T> {
     super();
   }
 
-  match(value: unknown): value is T {
+  matchValue(value: unknown): value is T {
     return this.capturedMatcher.current === value;
   }
 }

--- a/packages/matchers/src/matchers/oneOf.ts
+++ b/packages/matchers/src/matchers/oneOf.ts
@@ -1,0 +1,23 @@
+import Matcher from './Matcher';
+
+export class OneOfMatcher<T> extends Matcher<[T]> {
+  constructor(private readonly matcher: Matcher<T>) {
+    super();
+  }
+
+  match(value: unknown): value is [T] {
+    if (!Array.isArray(value)) {
+      return false;
+    }
+
+    if (value.length !== 1) {
+      return false;
+    }
+
+    return this.matcher.match(value[0]);
+  }
+}
+
+export default function oneOf<T>(matcher: Matcher<T>): Matcher<[T]> {
+  return new OneOfMatcher(matcher);
+}

--- a/packages/matchers/src/matchers/oneOf.ts
+++ b/packages/matchers/src/matchers/oneOf.ts
@@ -5,7 +5,7 @@ export class OneOfMatcher<T> extends Matcher<[T]> {
     super();
   }
 
-  match(value: unknown): value is [T] {
+  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is [T] {
     if (!Array.isArray(value)) {
       return false;
     }
@@ -14,7 +14,7 @@ export class OneOfMatcher<T> extends Matcher<[T]> {
       return false;
     }
 
-    return this.matcher.match(value[0]);
+    return this.matcher.matchValue(value[0], [...keys, 0]);
   }
 }
 

--- a/packages/matchers/src/matchers/or.ts
+++ b/packages/matchers/src/matchers/or.ts
@@ -1,0 +1,53 @@
+import Matcher from './Matcher';
+
+export class OrMatcher<T, A extends Array<Matcher<T> | T>> extends Matcher<T> {
+  private readonly matchersOrValues: A;
+
+  constructor(...matchersOrValues: A) {
+    super();
+    this.matchersOrValues = matchersOrValues;
+  }
+
+  match(value: unknown): value is T {
+    for (const matcherOrValue of this.matchersOrValues) {
+      if (matcherOrValue instanceof Matcher) {
+        if (matcherOrValue.match(value)) {
+          return true;
+        }
+      } else if (matcherOrValue === value) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+export default function or<T>(): Matcher<T>;
+export default function or<T>(first: Matcher<T> | T): Matcher<T>;
+export default function or<T, U>(
+  first: Matcher<T> | T,
+  second: Matcher<U> | U
+): Matcher<T | U>;
+export default function or<T, U, V>(
+  first: Matcher<T> | T,
+  second: Matcher<U> | U,
+  third: Matcher<V> | V
+): Matcher<T | U | V>;
+export default function or<T, U, V, W>(
+  first: Matcher<T> | T,
+  second: Matcher<U> | U,
+  third: Matcher<V> | V,
+  fourth: Matcher<W> | W
+): Matcher<T | U | V | W>;
+export default function or<T, U, V, W, X>(
+  first: Matcher<T> | T,
+  second: Matcher<U> | U,
+  third: Matcher<V> | V,
+  fourth: Matcher<W> | W,
+  fifth: Matcher<X> | X
+): Matcher<T | U | V | W | X>;
+export default function or<T, A extends Array<Matcher<T> | T>>(
+  ...matchersOrValues: A
+): Matcher<T> {
+  return new OrMatcher(...matchersOrValues);
+}

--- a/packages/matchers/src/matchers/or.ts
+++ b/packages/matchers/src/matchers/or.ts
@@ -8,10 +8,10 @@ export class OrMatcher<T, A extends Array<Matcher<T> | T>> extends Matcher<T> {
     this.matchersOrValues = matchersOrValues;
   }
 
-  match(value: unknown): value is T {
+  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is T {
     for (const matcherOrValue of this.matchersOrValues) {
       if (matcherOrValue instanceof Matcher) {
-        if (matcherOrValue.match(value)) {
+        if (matcherOrValue.matchValue(value, keys)) {
           return true;
         }
       } else if (matcherOrValue === value) {

--- a/packages/matchers/src/matchers/predicate.ts
+++ b/packages/matchers/src/matchers/predicate.ts
@@ -1,0 +1,17 @@
+import { Matcher } from '../matchers';
+
+export type Predicate<T> = (value: unknown) => boolean;
+
+export class PredicateMatcher<T> extends Matcher<T> {
+  constructor(private readonly predicate: Predicate<T>) {
+    super();
+  }
+
+  match(value: unknown): value is T {
+    return this.predicate(value);
+  }
+}
+
+export default function predicate<T>(predicate: Predicate<T>): Matcher<T> {
+  return new PredicateMatcher(predicate);
+}

--- a/packages/matchers/src/matchers/predicate.ts
+++ b/packages/matchers/src/matchers/predicate.ts
@@ -7,7 +7,7 @@ export class PredicateMatcher<T> extends Matcher<T> {
     super();
   }
 
-  match(value: unknown): value is T {
+  matchValue(value: unknown): value is T {
     return this.predicate(value);
   }
 }

--- a/packages/matchers/src/matchers/spacers.ts
+++ b/packages/matchers/src/matchers/spacers.ts
@@ -1,0 +1,15 @@
+export class Spacer {
+  constructor(readonly min: number, readonly max: number) {}
+}
+
+export function zeroOrMore(): Spacer {
+  return new Spacer(0, Infinity);
+}
+
+export function oneOrMore(): Spacer {
+  return new Spacer(1, Infinity);
+}
+
+export function spacer(min: number = 1, max: number = min): Spacer {
+  return new Spacer(min, max);
+}

--- a/packages/matchers/src/matchers/tupleOf.ts
+++ b/packages/matchers/src/matchers/tupleOf.ts
@@ -10,7 +10,7 @@ export class TupleOfMatcher<T, A extends Array<T> = Array<T>> extends Matcher<
     this.matchers = matchers;
   }
 
-  match(value: unknown): value is A {
+  matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is A {
     if (!Array.isArray(value)) {
       return false;
     }
@@ -23,7 +23,7 @@ export class TupleOfMatcher<T, A extends Array<T> = Array<T>> extends Matcher<
       const matcher = this.matchers[i];
       const element = value[i];
 
-      if (!matcher.match(element)) {
+      if (!matcher.matchValue(element, [...keys, i])) {
         return false;
       }
     }

--- a/packages/matchers/src/matchers/tupleOf.ts
+++ b/packages/matchers/src/matchers/tupleOf.ts
@@ -1,0 +1,39 @@
+import Matcher from './Matcher';
+
+export class TupleOfMatcher<T, A extends Array<T> = Array<T>> extends Matcher<
+  A
+> {
+  private readonly matchers: Array<Matcher<T>>;
+
+  constructor(...matchers: Array<Matcher<T>>) {
+    super();
+    this.matchers = matchers;
+  }
+
+  match(value: unknown): value is A {
+    if (!Array.isArray(value)) {
+      return false;
+    }
+
+    if (value.length !== this.matchers.length) {
+      return false;
+    }
+
+    for (let i = 0; i < this.matchers.length; i++) {
+      const matcher = this.matchers[i];
+      const element = value[i];
+
+      if (!matcher.match(element)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+export default function tupleOf<T, A extends Array<T> = Array<T>>(
+  ...matchers: Array<Matcher<T>>
+): Matcher<A> {
+  return new TupleOfMatcher(...matchers);
+}

--- a/packages/matchers/src/utils/distributeAcrossSpacers.ts
+++ b/packages/matchers/src/utils/distributeAcrossSpacers.ts
@@ -1,0 +1,33 @@
+import { Spacer } from '../matchers/spacers';
+
+export default function* distributeAcrossSpacers(
+  spacers: Array<Spacer>,
+  available: number
+): IterableIterator<Array<number>> {
+  if (spacers.length === 0) {
+    yield [];
+  } else if (spacers.length === 1) {
+    const spacer = spacers[0];
+
+    if (spacer.min <= available && available <= spacer.max) {
+      yield [available];
+    }
+  } else {
+    const last = spacers[spacers.length - 1];
+
+    for (
+      let allocateToLast = last.min;
+      allocateToLast <= last.max && allocateToLast <= available;
+      allocateToLast++
+    ) {
+      const allButLast = spacers.slice(0, -1);
+
+      for (const allButLastAllocations of distributeAcrossSpacers(
+        allButLast,
+        available - allocateToLast
+      )) {
+        yield [...allButLastAllocations, allocateToLast];
+      }
+    }
+  }
+}

--- a/packages/matchers/src/utils/match.ts
+++ b/packages/matchers/src/utils/match.ts
@@ -1,0 +1,55 @@
+import * as m from '../../src/matchers';
+
+/**
+ * This helper makes it easier to use a matcher together with captured values,
+ * especially from TypeScript. Essentially, this helper "unwraps" the captured
+ * values and passes them to the callback if the matcher matches the value. This
+ * prevents users of capturing matchers from needing to check the current
+ * captured value before using it.
+ *
+ * Here is an example codemod that turns e.g. `a + a` into `a * 2`. This
+ * is not actually something you'd want to do as `+` is used on more than
+ * just numbers, but it is suitable for purposes of illustration.
+ *
+ * @example
+ *
+ * import * as m from '@codemod/matchers';
+ *
+ * let id: m.CapturedMatcher<t.Identifier>;
+ * const idPlusIdMatcher = m.binaryExpression(
+ *   '+',
+ *   (id = m.capture(m.identifier())),
+ *   m.fromCapture(id)
+ * );
+ *
+ * export default function() {
+ *   return {
+ *     BinaryExpression(path: NodePath<t.BinaryExpression>): void {
+ *       m.match(idPlusIdMatcher, { id }, path.node, ({ id }) => {
+ *         path.replaceWith(t.binaryExpression('*', id, t.numericLiteral(2)));
+ *       });
+ *     }
+ *   };
+ * }
+ */
+export default function match<T, C extends { [key: string]: unknown }>(
+  matcher: m.Matcher<T>,
+  captures: { [K in keyof C]: m.CapturedMatcher<C[K]> },
+  value: T,
+  callback: (captures: C) => void
+): void {
+  if (matcher.match(value)) {
+    const capturedValues = {} as C;
+
+    for (const key in captures) {
+      if (Object.prototype.hasOwnProperty.call(captures, key)) {
+        const capturedValue = captures[key as keyof C].current;
+        if (capturedValue !== undefined) {
+          capturedValues[key as keyof C] = capturedValue;
+        }
+      }
+    }
+
+    callback(capturedValues);
+  }
+}

--- a/packages/matchers/src/utils/matchPath.ts
+++ b/packages/matchers/src/utils/matchPath.ts
@@ -1,0 +1,134 @@
+import * as m from '../../src/matchers';
+import * as t from '@babel/types';
+import { NodePath } from '@babel/traverse';
+
+export type CapturedNodePaths<C> = {
+  [K in keyof C]: C[K] extends t.Node ? NodePath<C[K]> : C[K]
+};
+export type CapturedMatchers<C> = { [K in keyof C]: m.CapturedMatcher<C[K]> };
+
+/**
+ * This helper makes it easier to use a matcher that captures `NodePath` values.
+ * Here is an example codemod that removes a redundant `-1` argument on `slice`
+ * calls:
+ *
+ * @example
+ *
+ * import * as m from '@codemod/matchers';
+ * import { PluginObj } from '@babel/core';
+ *
+ * const negativeOneArgument = m.capture(m.numericLiteral(-1));
+ * const sliceCallMatcher = m.callExpression(
+ *   m.memberExpression(
+ *     m.anyExpression(),
+ *     m.identifier('slice'),
+ *     false
+ *   ),
+ *   [m.anything(), negativeOneArgument]
+ * );
+ *
+ * export default function(): PluginObj {
+ *   return {
+ *     CallExpression(path: NodePath<t.CallExpression>): void {
+ *       m.matchPath(sliceCallMatcher, { negativeOneArgument }, path ({ negativeOneArgument }) => {
+ *         negativeOneArgument.remove();
+ *       });
+ *     }
+ *   };
+ * }
+ */
+export default function matchPath<
+  Node extends t.Node,
+  C extends { [key: string]: unknown }
+>(
+  matcher: m.Matcher<Node>,
+  captures: CapturedMatchers<C>,
+  value: NodePath<Node>,
+  callback: (paths: CapturedNodePaths<C>) => void
+): void;
+export default function matchPath<
+  Node extends t.Node,
+  C extends { [key: string]: unknown }
+>(
+  matcher: m.Matcher<Array<Node>>,
+  captures: CapturedMatchers<C>,
+  value: Array<NodePath<Node>>,
+  callback: (paths: CapturedNodePaths<C>) => void
+): void;
+export default function matchPath<
+  Node extends t.Node,
+  C extends { [key: string]: unknown }
+>(
+  matcher: m.Matcher<Node | Array<Node>>,
+  captures: CapturedMatchers<C>,
+  value: NodePath<Node> | Array<NodePath<Node>>,
+  callback: (paths: CapturedNodePaths<C>) => void
+): void {
+  const toMatch = Array.isArray(value)
+    ? value.map(element => element.node)
+    : value.node;
+  if (matcher.match(toMatch)) {
+    const capturedPaths = {} as CapturedNodePaths<C>;
+
+    for (const key in captures) {
+      if (Object.prototype.hasOwnProperty.call(captures, key)) {
+        const { current, currentKeys } = captures[key as keyof C];
+        if (current !== undefined && currentKeys !== undefined) {
+          capturedPaths[key as keyof C] = extractCapturedPath(
+            value,
+            currentKeys
+          );
+        }
+      }
+    }
+
+    callback(capturedPaths);
+  }
+}
+
+function extractCapturedPath<C extends { [key: string]: unknown }>(
+  value: NodePath<t.Node> | Array<NodePath<t.Node>>,
+  keys: ReadonlyArray<PropertyKey>
+): C[keyof C] extends t.Node ? NodePath<C[keyof C]> : C[keyof C] {
+  let capturedPath: NodePath<t.Node> | Array<NodePath<t.Node>> = value;
+
+  for (const [i, key] of keys.entries()) {
+    if (typeof key === 'string') {
+      if (Array.isArray(capturedPath)) {
+        throw new Error(
+          `failed to get '${keys.join('.')}'; at '${keys
+            .slice(0, i + 1)
+            .join('.')}' expected a NodePath but got an array`
+        );
+      }
+
+      capturedPath = capturedPath.get(key as string);
+    } else if (typeof key === 'number') {
+      if (!Array.isArray(capturedPath)) {
+        throw new Error(
+          `failed to get '${keys.join('.')}'; at '${keys
+            .slice(0, i + 1)
+            .join('.')}' expected an array but got a NodePath`
+        );
+      }
+
+      capturedPath = capturedPath[key];
+    } else {
+      throw new Error(
+        `failed to get '${keys.join('.')}'; key '${String(
+          key
+        )}' is neither a string nor a number, not ${typeof key}`
+      );
+    }
+  }
+
+  if (!Array.isArray(capturedPath) && typeof capturedPath.node !== 'object') {
+    return capturedPath.node as C[keyof C] extends t.Node
+      ? NodePath<C[keyof C]>
+      : C[keyof C];
+  } else {
+    return capturedPath as C[keyof C] extends t.Node
+      ? NodePath<C[keyof C]>
+      : C[keyof C];
+  }
+}

--- a/packages/matchers/tsconfig.json
+++ b/packages/matchers/tsconfig.json
@@ -1,0 +1,60 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/script/_utils/runCommand.js
+++ b/script/_utils/runCommand.js
@@ -13,9 +13,11 @@ module.exports = function(name) {
       main(process.argv.slice(2), process.stdin, process.stdout, process.stderr)
     );
   })
-    .then(status => process.exit(status))
+    .then(status => {
+      process.exitCode = status;
+    })
     .catch(error => {
       process.stderr.write(`[CRASH] ${error.stack}\n`);
-      process.exit(1);
+      process.exitCode = 1;
     });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
   integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.1.6":
+"@babel/core@^7.1.6", "@babel/core@^7.2.2":
   version "7.2.2"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz#07adba6dde27bb5ad8d8672f15fde3e08184a687"
   integrity sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==
@@ -1413,7 +1413,7 @@
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@types/babel__core@^7.0.2":
+"@types/babel__core@^7.0.2", "@types/babel__core@^7.0.4":
   version "7.0.4"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.0.4.tgz#14b30c11113bad353cabfaea73e327b48edb0f0e"
   integrity sha512-2Y2RK1BN5BRFfhneGfQA8mmFmTANbzGgS5uQPluoRqGNWb6uAcefqxzNbqgxPpmPkLqKapQfmYcyyl5iAQV+fA==
@@ -1428,12 +1428,25 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@^7.0.1":
+"@types/babel__template@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.1.tgz#8de6effa729bf0b0f65eb72399b629a3998a7f10"
+  integrity sha512-LT1zwkpL0/2oBP+npLaOCYSWv47cxbdAvONutjalMdCIBfjtfzVNnT8rgllBmsr15QAdAZDOmYw1CPhLB2JCtA==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@^7.0.1", "@types/babel__traverse@^7.0.4":
   version "7.0.4"
   resolved "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.4.tgz#de652399bd8493ab712e4d6b68031b7a2f72ad5f"
   integrity sha512-2vARZYqR4Flf59WtqMfa9GgbOjK04xLZaN9+CMf7Cs+4cAhxZBP3K9LYRzsWxOQe402VvqX9+7DdXxB72ujEOg==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@types/dedent@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
+  integrity sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==
 
 "@types/events@*":
   version "3.0.0"
@@ -1476,6 +1489,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/jest@^23.3.10":
+  version "23.3.13"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-23.3.13.tgz#c81484b6f4ca007bb09887ed15ecb3286d58f928"
+  integrity sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA==
+
 "@types/make-dir@^1.0.3":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@types/make-dir/-/make-dir-1.0.3.tgz#91fb52cefd07b0755d2373bcd46229765197ca3e"
@@ -1504,6 +1522,11 @@
   version "10.12.18"
   resolved "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+
+"@types/node@^10.12.18":
+  version "10.12.19"
+  resolved "https://registry.npmjs.org/@types/node/-/node-10.12.19.tgz#ca1018c26be01f07e66ac7fefbeb6407e4490c61"
+  integrity sha512-2NVovndCjJQj6fUUn9jCgpP4WSqr+u1SoUZMZyJkhGeBFsm6dE46l31S7lPUYt9uQ28XI+ibrJA1f5XyH5HNtA==
 
 "@types/prettier@^1.15.1":
   version "1.15.2"
@@ -1543,17 +1566,40 @@ JSONStream@^1.0.4, JSONStream@^1.3.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+abab@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
+  integrity sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+acorn-globals@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz#e3b6f8da3c1552a95ae627571f7dd6923bb54103"
+  integrity sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==
+  dependencies:
+    acorn "^6.0.1"
+    acorn-walk "^6.0.1"
 
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
   integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
 
-acorn@^6.0.2:
+acorn-walk@^6.0.1:
+  version "6.1.1"
+  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
+  integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
+
+acorn@^5.5.3:
+  version "5.7.3"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+
+acorn@^6.0.1, acorn@^6.0.2:
   version "6.0.5"
   resolved "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz#81730c0815f3f3b34d8efa95cb7430965f4d887a"
   integrity sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==
@@ -1639,6 +1685,21 @@ any-promise@^1.0.0:
   resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
+anymatch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+  integrity sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
+  dependencies:
+    micromatch "^3.1.4"
+    normalize-path "^2.1.1"
+
+append-transform@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+  integrity sha1-126/jKlNJ24keja61EpLdKthGZE=
+  dependencies:
+    default-require-extensions "^1.0.0"
+
 aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
   version "1.2.0"
   resolved "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -1664,12 +1725,19 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arr-diff@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
+  integrity sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=
+  dependencies:
+    arr-flatten "^1.0.1"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
   integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
-arr-flatten@^1.1.0:
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
   integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
@@ -1683,6 +1751,11 @@ array-differ@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
   integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
+
+array-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+  integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -1705,6 +1778,11 @@ array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
+
+array-unique@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+  integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1748,7 +1826,12 @@ astral-regex@^1.0.0:
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async@^2.5.0:
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
+
+async@^2.1.4, async@^2.5.0:
   version "2.6.1"
   resolved "https://registry.npmjs.org/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
@@ -1775,6 +1858,97 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
+babel-core@^6.0.0, babel-core@^6.26.0:
+  version "6.26.3"
+  resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
+
+babel-generator@^6.18.0, babel-generator@^6.26.0:
+  version "6.26.1"
+  resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
+  integrity sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.7"
+    trim-right "^1.0.1"
+
+babel-helpers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
+  integrity sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-jest@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz#a644232366557a2240a0c083da6b25786185a2f1"
+  integrity sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-istanbul@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  integrity sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
+  integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
+
+babel-plugin-syntax-object-rest-spread@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+  integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
+
 babel-polyfill@6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
@@ -1784,13 +1958,75 @@ babel-polyfill@6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-runtime@6.26.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  integrity sha1-jsegOhOPABoaj7HoETZSvxpV2kY=
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  integrity sha1-btAhFz4vy0htestFxgCahW9kcHE=
+  dependencies:
+    babel-core "^6.26.0"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    home-or-tmp "^2.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.15"
+
+babel-runtime@6.26.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1848,6 +2084,15 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+braces@^1.8.2:
+  version "1.8.5"
+  resolved "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
+  integrity sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=
+  dependencies:
+    expand-range "^1.8.1"
+    preserve "^0.2.0"
+    repeat-element "^1.1.2"
+
 braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
@@ -1864,6 +2109,18 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+browser-process-hrtime@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
+  integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
+
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
+  dependencies:
+    resolve "1.1.7"
+
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -1878,7 +2135,21 @@ browserslist@^4.3.4:
     electron-to-chromium "^1.3.103"
     node-releases "^1.1.3"
 
-buffer-from@^1.0.0, buffer-from@^1.1.0:
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
+bser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
+  integrity sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=
+  dependencies:
+    node-int64 "^0.4.0"
+
+buffer-from@1.x, buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -2029,6 +2300,13 @@ caniuse-lite@^1.0.30000929:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000930.tgz#c238bab82bedb462bcbdc61d0334932dcc084d8a"
   integrity sha512-KD+pw9DderBLB8CGqBzYyFWpnrPVOEjsjargU/CvkNyg60od3cxSPTcTeMPhxJhDbkQPWvOz5BAyBzNl/St9vg==
 
+capture-exit@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
+  integrity sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=
+  dependencies:
+    rsvp "^3.3.3"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -2161,6 +2439,11 @@ cmd-shim@^2.0.2:
   dependencies:
     graceful-fs "^4.1.2"
     mkdirp "~0.5.0"
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -2376,7 +2659,7 @@ conventional-recommended-bump@^4.0.4:
     meow "^4.0.0"
     q "^1.5.1"
 
-convert-source-map@^1.1.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.6.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
@@ -2464,6 +2747,18 @@ crypt@~0.0.1:
   resolved "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+  version "0.3.4"
+  resolved "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
+  integrity sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==
+
+cssstyle@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
+  integrity sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==
+  dependencies:
+    cssom "0.3.x"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -2490,6 +2785,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-urls@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
+  integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
+  dependencies:
+    abab "^2.0.0"
+    whatwg-mimetype "^2.2.0"
+    whatwg-url "^7.0.0"
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
@@ -2507,7 +2811,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^2.2.0, debug@^2.3.3:
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -2563,10 +2867,22 @@ dedent@^0.7.0:
   resolved "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+default-require-extensions@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+  integrity sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=
+  dependencies:
+    strip-bom "^2.0.0"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -2574,6 +2890,13 @@ defaults@^1.0.3:
   integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
+
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -2619,10 +2942,27 @@ delegates@^1.0.0:
   resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
+  dependencies:
+    repeating "^2.0.0"
+
 detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
+
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -2632,7 +2972,7 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-diff@3.5.0, diff@^3.1.0:
+diff@3.5.0, diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -2651,6 +2991,13 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
+
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -2730,6 +3077,27 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.5.1:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
 es6-promise@^4.0.3:
   version "4.2.5"
   resolved "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
@@ -2746,6 +3114,18 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escodegen@^1.9.1:
+  version "1.11.0"
+  resolved "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
+  integrity sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
 
 eslint-config-prettier@^3.3.0:
   version "3.6.0"
@@ -2839,6 +3219,11 @@ espree@^5.0.0:
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
+esprima@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
+
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -2858,7 +3243,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
@@ -2867,6 +3252,13 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+
+exec-sh@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
+  integrity sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==
+  dependencies:
+    merge "^1.2.0"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -2907,6 +3299,18 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
+
+expand-brackets@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
+  integrity sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=
+  dependencies:
+    is-posix-bracket "^0.1.0"
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -2919,6 +3323,25 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+expand-range@^1.8.1:
+  version "1.8.2"
+  resolved "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
+  integrity sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
+  dependencies:
+    fill-range "^2.1.0"
+
+expect@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz#1e0c8d3ba9a581c87bd71fb9bc8862d443425f98"
+  integrity sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^23.6.0"
+    jest-get-type "^22.1.0"
+    jest-matcher-utils "^23.6.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -2948,6 +3371,13 @@ external-editor@^3.0.0, external-editor@^3.0.3:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
+
+extglob@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+  integrity sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=
+  dependencies:
+    is-extglob "^1.0.0"
 
 extglob@^2.0.4:
   version "2.0.4"
@@ -2995,7 +3425,7 @@ fast-glob@^2.0.2:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
@@ -3004,6 +3434,13 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fb-watchman@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
+  integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
+  dependencies:
+    bser "^2.0.0"
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -3032,6 +3469,30 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+filename-regex@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+  integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
+
+fileset@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
+  integrity sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=
+  dependencies:
+    glob "^7.0.3"
+    minimatch "^3.0.3"
+
+fill-range@^2.1.0:
+  version "2.2.4"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
+  integrity sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==
+  dependencies:
+    is-number "^2.1.0"
+    isobject "^2.0.0"
+    randomatic "^3.0.0"
+    repeat-element "^1.1.2"
+    repeat-string "^1.5.2"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -3093,10 +3554,17 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-for-in@^1.0.2:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+for-own@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
+  dependencies:
+    for-in "^1.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -3167,6 +3635,14 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@^1.2.3:
+  version "1.2.7"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
+  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
+  dependencies:
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
+
 fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.11"
   resolved "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
@@ -3176,6 +3652,11 @@ fstream@^1.0.0, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -3339,6 +3820,21 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
+glob-base@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+  integrity sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=
+  dependencies:
+    glob-parent "^2.0.0"
+    is-glob "^2.0.0"
+
+glob-parent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
+  integrity sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
+  dependencies:
+    is-glob "^2.0.0"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -3387,6 +3883,11 @@ globals@^11.1.0, globals@^11.7.0:
   version "11.10.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
   integrity sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==
+
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
 globby@^6.1.0:
   version "6.1.0"
@@ -3445,7 +3946,12 @@ growl@1.10.5:
   resolved "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-handlebars@^4.0.2:
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+  integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+handlebars@^4.0.2, handlebars@^4.0.3:
   version "4.0.12"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
   integrity sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==
@@ -3476,6 +3982,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -3485,6 +3996,11 @@ has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
   integrity sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
@@ -3529,15 +4045,37 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+has@^1.0.1, has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
   integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
+home-or-tmp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
+  integrity sha1-42w/LSyufXRqhX440Y1fMqeILbg=
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.1"
+
 hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
   version "2.7.1"
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
+
+html-encoding-sniffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
+  integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
+  dependencies:
+    whatwg-encoding "^1.0.1"
 
 http-cache-semantics@3.8.1, http-cache-semantics@^3.8.1:
   version "3.8.1"
@@ -3592,7 +4130,7 @@ husky@^1.1.4:
     run-node "^1.0.0"
     slash "^2.0.0"
 
-iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -3675,7 +4213,7 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@^1.3.5:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -3740,7 +4278,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.2.2:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -3756,6 +4294,11 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+ip-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-3.0.0.tgz#0a934694b4066558c46294244a23cc33116bf732"
+  integrity sha512-T8wDtjy+Qf2TAPDQmBp0eGKJ8GavlWlUnamr3wRn6vvdZlKVuJXXMlSncYFRYgVHOM3If5NR1H4+OvVQU9Idvg==
 
 ip@^1.1.5:
   version "1.1.5"
@@ -3793,6 +4336,11 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
 is-ci@^1.0.10:
   version "1.2.1"
   resolved "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
@@ -3821,6 +4369,11 @@ is-data-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
@@ -3844,6 +4397,18 @@ is-directory@^0.3.1:
   resolved "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-dotfile@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
+  integrity sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=
+
+is-equal-shallow@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+  integrity sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=
+  dependencies:
+    is-primitive "^2.0.0"
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -3855,6 +4420,11 @@ is-extendable@^1.0.1:
   integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
     is-plain-object "^2.0.4"
+
+is-extglob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+  integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
 
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
@@ -3880,6 +4450,18 @@ is-fullwidth-code-point@^2.0.0:
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
+is-generator-fn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
+  integrity sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=
+
+is-glob@^2.0.0, is-glob@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
+  dependencies:
+    is-extglob "^1.0.0"
+
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -3894,12 +4476,24 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-number@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  integrity sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=
+  dependencies:
+    kind-of "^3.0.2"
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
 is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
@@ -3949,10 +4543,27 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-posix-bracket@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+  integrity sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=
+
+is-primitive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+  integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
+
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+  dependencies:
+    has "^1.0.1"
 
 is-regexp@^1.0.0:
   version "1.0.0"
@@ -3973,6 +4584,13 @@ is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
   integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-text-path@^1.0.0:
   version "1.0.1"
@@ -4023,6 +4641,76 @@ isstream@~0.1.2:
   resolved "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+istanbul-api@^1.3.1:
+  version "1.3.7"
+  resolved "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz#a86c770d2b03e11e3f778cd7aedd82d2722092aa"
+  integrity sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==
+  dependencies:
+    async "^2.1.4"
+    fileset "^2.0.2"
+    istanbul-lib-coverage "^1.2.1"
+    istanbul-lib-hook "^1.2.2"
+    istanbul-lib-instrument "^1.10.2"
+    istanbul-lib-report "^1.1.5"
+    istanbul-lib-source-maps "^1.2.6"
+    istanbul-reports "^1.5.1"
+    js-yaml "^3.7.0"
+    mkdirp "^0.5.1"
+    once "^1.4.0"
+
+istanbul-lib-coverage@^1.2.0, istanbul-lib-coverage@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#ccf7edcd0a0bb9b8f729feeb0930470f9af664f0"
+  integrity sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==
+
+istanbul-lib-hook@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz#bc6bf07f12a641fbf1c85391d0daa8f0aea6bf86"
+  integrity sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==
+  dependencies:
+    append-transform "^0.4.0"
+
+istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz#1f55ed10ac3c47f2bdddd5307935126754d0a9ca"
+  integrity sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.2.1"
+    semver "^5.3.0"
+
+istanbul-lib-report@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz#f2a657fc6282f96170aaf281eb30a458f7f4170c"
+  integrity sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==
+  dependencies:
+    istanbul-lib-coverage "^1.2.1"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
+istanbul-lib-source-maps@^1.2.4, istanbul-lib-source-maps@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz#37b9ff661580f8fca11232752ee42e08c6675d8f"
+  integrity sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.2.1"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz#97e4dbf3b515e8c484caea15d6524eebd3ff4e1a"
+  integrity sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==
+  dependencies:
+    handlebars "^4.0.3"
+
 isurl@^1.0.0-alpha5:
   version "1.0.0"
   resolved "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
@@ -4031,12 +4719,290 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
+jest-changed-files@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
+  integrity sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==
+  dependencies:
+    throat "^4.0.0"
+
+jest-cli@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz#61ab917744338f443ef2baa282ddffdd658a5da4"
+  integrity sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    import-local "^1.0.0"
+    is-ci "^1.0.10"
+    istanbul-api "^1.3.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-source-maps "^1.2.4"
+    jest-changed-files "^23.4.2"
+    jest-config "^23.6.0"
+    jest-environment-jsdom "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^23.6.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve-dependencies "^23.6.0"
+    jest-runner "^23.6.0"
+    jest-runtime "^23.6.0"
+    jest-snapshot "^23.6.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.6.0"
+    jest-watcher "^23.4.0"
+    jest-worker "^23.2.0"
+    micromatch "^2.3.11"
+    node-notifier "^5.2.1"
+    prompts "^0.1.9"
+    realpath-native "^1.0.0"
+    rimraf "^2.5.4"
+    slash "^1.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
+    which "^1.2.12"
+    yargs "^11.0.0"
+
+jest-config@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz#f82546a90ade2d8c7026fbf6ac5207fc22f8eb1d"
+  integrity sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==
+  dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^23.6.0"
+    chalk "^2.0.1"
+    glob "^7.1.1"
+    jest-environment-jsdom "^23.4.0"
+    jest-environment-node "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^23.6.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.6.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.6.0"
+    micromatch "^2.3.11"
+    pretty-format "^23.6.0"
+
+jest-diff@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz#1500f3f16e850bb3d71233408089be099f610c7d"
+  integrity sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.6.0"
+
+jest-docblock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
+  integrity sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=
+  dependencies:
+    detect-newline "^2.1.0"
+
+jest-each@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz#ba0c3a82a8054387016139c733a05242d3d71575"
+  integrity sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==
+  dependencies:
+    chalk "^2.0.1"
+    pretty-format "^23.6.0"
+
+jest-environment-jsdom@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
+  integrity sha1-BWp5UrP+pROsYqFAosNox52eYCM=
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+    jsdom "^11.5.1"
+
+jest-environment-node@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
+  integrity sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+
 jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
   integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
 
-jest-validate@^23.5.0:
+jest-haste-map@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz#2e3eb997814ca696d62afdb3f2529f5bbc935e16"
+  integrity sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    invariant "^2.2.4"
+    jest-docblock "^23.2.0"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.2.0"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
+
+jest-jasmine2@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz#840e937f848a6c8638df24360ab869cc718592e0"
+  integrity sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==
+  dependencies:
+    babel-traverse "^6.0.0"
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^23.6.0"
+    is-generator-fn "^1.0.0"
+    jest-diff "^23.6.0"
+    jest-each "^23.6.0"
+    jest-matcher-utils "^23.6.0"
+    jest-message-util "^23.4.0"
+    jest-snapshot "^23.6.0"
+    jest-util "^23.4.0"
+    pretty-format "^23.6.0"
+
+jest-leak-detector@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz#e4230fd42cf381a1a1971237ad56897de7e171de"
+  integrity sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==
+  dependencies:
+    pretty-format "^23.6.0"
+
+jest-matcher-utils@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz#726bcea0c5294261a7417afb6da3186b4b8cac80"
+  integrity sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.6.0"
+
+jest-message-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
+  integrity sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    stack-utils "^1.0.1"
+
+jest-mock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
+  integrity sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=
+
+jest-regex-util@^23.3.0:
+  version "23.3.0"
+  resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
+  integrity sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U=
+
+jest-resolve-dependencies@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz#b4526af24c8540d9a3fab102c15081cf509b723d"
+  integrity sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==
+  dependencies:
+    jest-regex-util "^23.3.0"
+    jest-snapshot "^23.6.0"
+
+jest-resolve@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz#cf1d1a24ce7ee7b23d661c33ba2150f3aebfa0ae"
+  integrity sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==
+  dependencies:
+    browser-resolve "^1.11.3"
+    chalk "^2.0.1"
+    realpath-native "^1.0.0"
+
+jest-runner@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz#3894bd219ffc3f3cb94dc48a4170a2e6f23a5a38"
+  integrity sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==
+  dependencies:
+    exit "^0.1.2"
+    graceful-fs "^4.1.11"
+    jest-config "^23.6.0"
+    jest-docblock "^23.2.0"
+    jest-haste-map "^23.6.0"
+    jest-jasmine2 "^23.6.0"
+    jest-leak-detector "^23.6.0"
+    jest-message-util "^23.4.0"
+    jest-runtime "^23.6.0"
+    jest-util "^23.4.0"
+    jest-worker "^23.2.0"
+    source-map-support "^0.5.6"
+    throat "^4.0.0"
+
+jest-runtime@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz#059e58c8ab445917cd0e0d84ac2ba68de8f23082"
+  integrity sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==
+  dependencies:
+    babel-core "^6.0.0"
+    babel-plugin-istanbul "^4.1.6"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-config "^23.6.0"
+    jest-haste-map "^23.6.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.6.0"
+    jest-snapshot "^23.6.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.6.0"
+    micromatch "^2.3.11"
+    realpath-native "^1.0.0"
+    slash "^1.0.0"
+    strip-bom "3.0.0"
+    write-file-atomic "^2.1.0"
+    yargs "^11.0.0"
+
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
+  integrity sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=
+
+jest-snapshot@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz#f9c2625d1b18acda01ec2d2b826c0ce58a5aa17a"
+  integrity sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==
+  dependencies:
+    babel-types "^6.0.0"
+    chalk "^2.0.1"
+    jest-diff "^23.6.0"
+    jest-matcher-utils "^23.6.0"
+    jest-message-util "^23.4.0"
+    jest-resolve "^23.6.0"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^23.6.0"
+    semver "^5.5.0"
+
+jest-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
+  integrity sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=
+  dependencies:
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    jest-message-util "^23.4.0"
+    mkdirp "^0.5.1"
+    slash "^1.0.0"
+    source-map "^0.6.0"
+
+jest-validate@^23.5.0, jest-validate@^23.6.0:
   version "23.6.0"
   resolved "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
   integrity sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==
@@ -4045,6 +5011,30 @@ jest-validate@^23.5.0:
     jest-get-type "^22.1.0"
     leven "^2.1.0"
     pretty-format "^23.6.0"
+
+jest-watcher@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
+  integrity sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
+jest-worker@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
+  integrity sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=
+  dependencies:
+    merge-stream "^1.0.1"
+
+jest@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
+  integrity sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==
+  dependencies:
+    import-local "^1.0.0"
+    jest-cli "^23.6.0"
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -4056,7 +5046,12 @@ js-levenshtein@^1.1.3:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.12.0, js-yaml@^3.9.0:
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
+js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
   integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
@@ -4068,6 +5063,43 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsdom@^11.5.1:
+  version "11.12.0"
+  resolved "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
+  integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
+  dependencies:
+    abab "^2.0.0"
+    acorn "^5.5.3"
+    acorn-globals "^4.1.0"
+    array-equal "^1.0.0"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle "^1.0.0"
+    data-urls "^1.0.0"
+    domexception "^1.0.1"
+    escodegen "^1.9.1"
+    html-encoding-sniffer "^1.0.2"
+    left-pad "^1.3.0"
+    nwsapi "^2.0.7"
+    parse5 "4.0.0"
+    pn "^1.1.0"
+    request "^2.87.0"
+    request-promise-native "^1.0.5"
+    sax "^1.2.4"
+    symbol-tree "^3.2.2"
+    tough-cookie "^2.3.4"
+    w3c-hr-time "^1.0.1"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.3"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
+    ws "^5.2.0"
+    xml-name-validator "^3.0.0"
+
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+  integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -4109,12 +5141,17 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.0:
+json5@2.x, json5@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
+
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -4169,6 +5206,11 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+kleur@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"
+  integrity sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==
+
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -4182,6 +5224,11 @@ lcid@^2.0.0:
   integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
   dependencies:
     invert-kv "^2.0.0"
+
+left-pad@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
+  integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
 lerna@^3.10.7:
   version "3.10.7"
@@ -4473,7 +5520,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@^4.2.1:
+lodash@4.17.11, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -4548,7 +5595,7 @@ make-dir@^1.0.0, make-dir@^1.3.0:
   dependencies:
     pify "^3.0.0"
 
-make-error@^1.1.1:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.5"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
@@ -4569,6 +5616,13 @@ make-fetch-happen@^4.0.1:
     promise-retry "^1.1.1"
     socks-proxy-agent "^4.0.0"
     ssri "^6.0.0"
+
+makeerror@1.0.x:
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+  integrity sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
+  dependencies:
+    tmpl "1.0.x"
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -4605,6 +5659,11 @@ matcher@^1.0.0:
   integrity sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==
   dependencies:
     escape-string-regexp "^1.0.4"
+
+math-random@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
+  integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
 
 md5@^2.1.0:
   version "2.2.1"
@@ -4677,12 +5736,43 @@ meow@^4.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
 
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  integrity sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
+  dependencies:
+    readable-stream "^2.0.1"
+
 merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
 
-micromatch@^3.1.10, micromatch@^3.1.8:
+merge@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
+
+micromatch@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
+  integrity sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=
+  dependencies:
+    arr-diff "^2.0.0"
+    array-unique "^0.2.1"
+    braces "^1.8.2"
+    expand-brackets "^0.1.4"
+    extglob "^0.3.1"
+    filename-regex "^2.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.1"
+    kind-of "^3.0.2"
+    normalize-path "^2.0.1"
+    object.omit "^2.0.0"
+    parse-glob "^3.0.4"
+    regex-cache "^0.4.2"
+
+micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -4723,7 +5813,7 @@ mimic-response@^1.0.0:
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -4743,7 +5833,7 @@ minimist@0.0.8:
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -4792,7 +5882,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -4883,6 +5973,11 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nan@^2.9.2:
+  version "2.12.1"
+  resolved "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
+  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4904,6 +5999,15 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+needle@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
+  integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -4937,10 +6041,41 @@ node-gyp@^3.8.0:
     tar "^2.0.0"
     which "1"
 
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+  integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+
+node-notifier@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz#c77a4a7b84038733d5fb351aafd8a268bfe19a01"
+  integrity sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==
+  dependencies:
+    growly "^1.3.0"
+    semver "^5.5.0"
+    shellwords "^0.1.1"
+    which "^1.3.0"
+
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
 
 node-releases@^1.1.3:
   version "1.1.3"
@@ -4955,6 +6090,14 @@ node-releases@^1.1.3:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
+
+nopt@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0:
   version "2.5.0"
@@ -4976,6 +6119,13 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^2.0.1, normalize-path@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
 normalize-url@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
@@ -4986,9 +6136,9 @@ normalize-url@2.0.1:
     sort-keys "^2.0.0"
 
 npm-bundled@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
-  integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
+  integrity sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==
 
 npm-lifecycle@^2.1.0:
   version "2.1.0"
@@ -5023,6 +6173,14 @@ npm-packlist@^1.1.12:
   version "1.3.0"
   resolved "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.3.0.tgz#7f01e8e44408341379ca98cfd756e7b29bd2626c"
   integrity sha512-qPBc6CnxEzpOcc4bjoIBJbYdy0D/LFFPUdxvfwor4/w3vxeE0h6TiOVurCEPpQ6trjN77u/ShyfeJGsbAfB3dA==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+
+npm-packlist@^1.1.6:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz#55a60e793e272f00862c7089274439a4cc31fc7f"
+  integrity sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -5080,7 +6238,7 @@ npm-which@^3.0.1:
     npm-path "^2.0.2"
     which "^1.2.10"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -5094,6 +6252,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
+nwsapi@^2.0.7:
+  version "2.0.9"
+  resolved "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz#77ac0cdfdcad52b6a1151a84e73254edc33ed016"
+  integrity sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -5114,12 +6277,33 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
+
+object.omit@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+  integrity sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=
+  dependencies:
+    for-own "^0.1.4"
+    is-extendable "^0.1.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -5150,7 +6334,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.2:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
@@ -5185,12 +6369,12 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.5:
+osenv@0, osenv@^0.1.4, osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -5356,6 +6540,16 @@ parse-github-repo-url@^1.3.0:
   resolved "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz#9e7d8bb252a6cb6ba42595060b7bf6df3dbc1f50"
   integrity sha1-nn2LslKmy2ukJZUGC3v23z28H1A=
 
+parse-glob@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
+  integrity sha1-ssN2z7EfNVE7rdFz7wu246OIORw=
+  dependencies:
+    glob-base "^0.3.0"
+    is-dotfile "^1.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.0"
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -5370,6 +6564,11 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse5@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+  integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -5393,7 +6592,7 @@ path-exists@^3.0.0:
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
-path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
@@ -5408,7 +6607,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-parse@^1.0.6:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
@@ -5489,6 +6688,11 @@ pluralize@^7.0.0:
   resolved "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -5503,6 +6707,11 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+preserve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+  integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
@@ -5524,7 +6733,7 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-private@^0.1.6, private@~0.1.5:
+private@^0.1.6, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.npmjs.org/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -5552,6 +6761,14 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
+prompts@^0.1.9:
+  version "0.1.14"
+  resolved "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
+  integrity sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==
+  dependencies:
+    kleur "^2.0.1"
+    sisteransi "^0.1.1"
+
 promzard@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
@@ -5576,7 +6793,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.24:
+psl@^1.1.24, psl@^1.1.28:
   version "1.1.31"
   resolved "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
   integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
@@ -5611,7 +6828,7 @@ punycode@^1.4.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -5639,6 +6856,25 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
+
+randomatic@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz#b776efc59375984e36c537b2f51a1f0aff0da1ed"
+  integrity sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==
+  dependencies:
+    is-number "^4.0.0"
+    kind-of "^6.0.0"
+    math-random "^1.0.1"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -5720,7 +6956,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -5751,6 +6987,13 @@ readdir-scoped-modules@^1.0.0:
     dezalgo "^1.0.0"
     graceful-fs "^4.1.2"
     once "^1.3.0"
+
+realpath-native@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz#cd51ce089b513b45cf9b1516c82989b51ccc6560"
+  integrity sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==
+  dependencies:
+    util.promisify "^1.0.0"
 
 recast@^0.16.1:
   version "0.16.2"
@@ -5812,6 +7055,13 @@ regenerator-transform@^0.13.3:
   dependencies:
     private "^0.1.6"
 
+regex-cache@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
+  integrity sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
+  dependencies:
+    is-equal-shallow "^0.1.3"
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -5858,12 +7108,17 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
 repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -5874,6 +7129,22 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
+
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  integrity sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  integrity sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
 
 request@^2.87.0:
   version "2.88.0"
@@ -5975,7 +7246,12 @@ resolve-url@^0.2.1:
   resolved "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.3.2, resolve@^1.7.1:
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+
+resolve@1.x, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.7.1:
   version "1.10.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -6007,7 +7283,7 @@ retry@^0.10.0:
   resolved "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -6020,6 +7296,11 @@ rimraf@2.6.2:
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
+
+rsvp@^3.3.3:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+  integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -6071,12 +7352,33 @@ safe-regex@^1.1.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sane@^2.0.0:
+  version "2.5.2"
+  resolved "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
+  integrity sha1-tNwYYcIbQn6SlQej51HiosuKs/o=
+  dependencies:
+    anymatch "^2.0.0"
+    capture-exit "^1.2.0"
+    exec-sh "^0.2.0"
+    fb-watchman "^2.0.0"
+    micromatch "^3.1.4"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+    watch "~0.18.0"
+  optionalDependencies:
+    fsevents "^1.2.3"
+
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@5.6.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@5.6.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -6128,6 +7430,11 @@ shebang-regex@^1.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
+shellwords@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -6139,6 +7446,11 @@ simple-git@^1.85.0:
   integrity sha512-t4OK1JRlp4ayKRfcW6owrWcRVLyHRUlhGd0uN6ZZTqfDq8a5XpcUdOKiGRNobHEuMtNqzp0vcJNvhYWwh5PsQA==
   dependencies:
     debug "^4.0.1"
+
+sisteransi@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
+  integrity sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==
 
 slash@^1.0.0:
   version "1.0.0"
@@ -6238,6 +7550,13 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.4.15:
+  version "0.4.18"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
+  dependencies:
+    source-map "^0.5.6"
+
 source-map-support@^0.5.6:
   version "0.5.10"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
@@ -6251,7 +7570,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -6335,6 +7654,11 @@ ssri@^6.0.0, ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
+stack-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
+  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
 staged-git-files@1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.2.tgz#4326d33886dc9ecfa29a6193bf511ba90a46454b"
@@ -6347,6 +7671,11 @@ static-extend@^0.1.1:
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
+
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
 stream-each@^1.1.0:
   version "1.2.3"
@@ -6370,6 +7699,14 @@ string-argv@^0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
   integrity sha1-2sMECGkMIfPDYwo/86BYd73L1zY=
+
+string-length@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
+  integrity sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^4.0.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -6437,17 +7774,17 @@ strip-ansi@^5.0.0:
   dependencies:
     ansi-regex "^4.0.0"
 
+strip-bom@3.0.0, strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
   dependencies:
     is-utf8 "^0.2.0"
-
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -6466,7 +7803,7 @@ strip-indent@^2.0.0:
   resolved "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@^2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -6492,6 +7829,13 @@ supports-color@^2.0.0:
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
+supports-color@^3.1.2:
+  version "3.2.3"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
+  dependencies:
+    has-flag "^1.0.0"
+
 supports-color@^5.2.0, supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -6503,6 +7847,11 @@ symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
+symbol-tree@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+  integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
 table@^5.0.2:
   version "5.2.1"
@@ -6523,7 +7872,7 @@ tar@^2.0.0:
     fstream "^1.0.2"
     inherits "2"
 
-tar@^4.4.8:
+tar@^4, tar@^4.4.8:
   version "4.4.8"
   resolved "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
   integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
@@ -6553,6 +7902,17 @@ temp-write@^3.4.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
+test-exclude@^4.2.1:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz#a9a5e64474e4398339245a0a769ad7c2f4a97c20"
+  integrity sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^2.3.11"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
 text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
@@ -6576,6 +7936,11 @@ thenify-all@^1.0.0:
   integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   dependencies:
     any-promise "^1.0.0"
+
+throat@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+  integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
 through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"
@@ -6601,6 +7966,16 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmpl@1.0.x:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
+  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -6631,6 +8006,23 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+tough-cookie@>=2.3.3:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.0.tgz#d2bceddebde633153ff20a52fa844a0dc71dacef"
+  integrity sha512-LHMvg+RBP/mAVNqVbOX8t+iJ+tqhBA/t49DuI7+IDAWHrASnesqSu1vWbKB7UrE2yk+HMFUBMadRGMkB4VCfog==
+  dependencies:
+    ip-regex "^3.0.0"
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@^2.3.4:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
 
 tough-cookie@~2.4.3:
   version "2.4.3"
@@ -6666,6 +8058,21 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+ts-jest@^23.10.5:
+  version "23.10.5"
+  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.5.tgz#cdb550df4466a30489bf70ba867615799f388dd5"
+  integrity sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "10.x"
 
 ts-node@^7.0.1:
   version "7.0.1"
@@ -6844,6 +8251,14 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
+
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -6873,6 +8288,28 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+w3c-hr-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
+  dependencies:
+    browser-process-hrtime "^0.1.2"
+
+walker@~1.0.5:
+  version "1.0.7"
+  resolved "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
+  dependencies:
+    makeerror "1.0.x"
+
+watch@~0.18.0:
+  version "0.18.0"
+  resolved "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
+  integrity sha1-KAlUdsbffJDJYxOJkMClQj60uYY=
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
+
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
@@ -6884,6 +8321,27 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
+  dependencies:
+    iconv-lite "0.4.24"
+
+whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whatwg-url@^7.0.0:
   version "7.0.0"
@@ -6899,7 +8357,7 @@ which-module@^2.0.0:
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1, which@^1.2.10, which@^1.2.9, which@^1.3.1:
+which@1, which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -6944,7 +8402,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
+write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
   version "2.4.2"
   resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
   integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
@@ -6980,6 +8438,18 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
 xml@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
@@ -7010,7 +8480,7 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-yargs-parser@^10.0.0:
+yargs-parser@10.x, yargs-parser@^10.0.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
@@ -7032,6 +8502,13 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@^10.0.3:
   version "10.1.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
@@ -7049,6 +8526,24 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^12.0.1:
   version "12.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4295,10 +4295,10 @@ invert-kv@^2.0.0:
   resolved "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-ip-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-3.0.0.tgz#0a934694b4066558c46294244a23cc33116bf732"
-  integrity sha512-T8wDtjy+Qf2TAPDQmBp0eGKJ8GavlWlUnamr3wRn6vvdZlKVuJXXMlSncYFRYgVHOM3If5NR1H4+OvVQU9Idvg==
+ip-regex@^2.0.0, ip-regex@^3.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
 ip@^1.1.5:
   version "1.1.5"


### PR DESCRIPTION
This PR introduces a new package into the monorepo: `@codemod/matchers`.

The idea is that most codemods devolve into a whole lot of nested `if`s or guard statements intermixed with some variable declarations and confusion around whether to use the `NodePath` API or just mutate DOM nodes directly. `@codemod/matchers` aims to help with these problems. The basic API just builds an object which can match a particular AST pattern:

```ts
// matches `this.*(…)`
const matchThisMethodCall = m.callExpression(
  m.memberExpression(
    m.thisExpression(),
    m.identifier(),
    false
  )
);

if (matchThisMethodCall.match(node)) {
  // do something
}
```

But you can also [capture](https://github.com/codemod-js/codemod/blob/367514dc9805ca133e239b3e4e87908e5a1a21e1/packages/matchers/src/matchers/capture.ts) values:

```ts
// matches `this.*(…)`
const methodName = m.capture(m.anyString());
const matchThisMethodCall = m.callExpression(
  m.memberExpression(
    m.thisExpression(),
    m.identifier(methodName),
    false
  )
);

if (matchThisMethodCall.match(node)) {
  console.log(`found a method call for ${methodName.current}`);
}
```

Finally, it ships with a [`matchPath` helper](https://github.com/codemod-js/codemod/blob/367514dc9805ca133e239b3e4e87908e5a1a21e1/packages/matchers/src/utils/matchPath.ts) for use in the context of `@babel/traverse` visitors, i.e. in babel plugins/codemods:

```ts
// This codemod removes an unnecessary second `-1` argument on `slice` calls.

import * as m from '@codemod/matchers';
import { PluginObj } from '@babel/core';

const negativeOneArgument = m.capture(m.numericLiteral(-1));
const sliceCallMatcher = m.callExpression(
  m.memberExpression(
    m.anyExpression(),
    m.identifier('slice'),
    false
  ),
  [m.anything(), negativeOneArgument]
);

export default function(): PluginObj {
  return {
    CallExpression(path: NodePath<t.CallExpression>): void {
      m.matchPath(sliceCallMatcher, { negativeOneArgument }, path ({ negativeOneArgument }) => {
        negativeOneArgument.remove();
      });
    }
  };
}
```

See [this file](https://github.com/codemod-js/codemod/blob/367514dc9805ca133e239b3e4e87908e5a1a21e1/packages/matchers/examples/convert-static-class-to-named-exports.ts) for a full non-trivial example codemod using `@codemod/matchers`, and [integration.test.ts](https://github.com/codemod-js/codemod/blob/367514dc9805ca133e239b3e4e87908e5a1a21e1/packages/matchers/src/__tests__/integration.test.ts) for a series of semi-realistic examples.

cc @lennyburdette @benjamn @baweaver @hzoo @alexhancock @monicab @tingc10

---

In addition to waiting for review from some folks, this is a bit blocked on figuring out the automated release story. I'd like to use lerna with semantic-release but I don't see any good prior art. I'm also willing to ditch semantic-release if I can still get the same effect but do something on my computer to bump the versions but have CI publish. Ideas?