### PR TITLE
refactor: remove unneeded syntax flags

### DIFF
--- a/packages/matchers/src/__tests__/utils/builders.ts
+++ b/packages/matchers/src/__tests__/utils/builders.ts
@@ -93,12 +93,7 @@ export function BuildStatements<
     code += quasis[i + 1];
   }
 
-  const ast = parse(code, {
-    allowAwaitOutsideFunction: true,
-    allowImportExportEverywhere: true,
-    allowReturnOutsideFunction: true,
-    allowSuperOutsideMethod: true
-  });
+  const ast = parse(code);
   const replaced = new Map<number, InterpolationValue>();
 
   traverse(ast, {

--- a/packages/matchers/src/__tests__/utils/parse/js.ts
+++ b/packages/matchers/src/__tests__/utils/parse/js.ts
@@ -7,14 +7,7 @@ function fieldsForNodeType(nodeType: string): Set<string> {
 }
 
 export default function js(code: string): t.File {
-  return stripExtras(
-    parse(code, {
-      allowAwaitOutsideFunction: true,
-      allowImportExportEverywhere: true,
-      allowReturnOutsideFunction: true,
-      allowSuperOutsideMethod: true
-    })
-  );
+  return stripExtras(parse(code));
 }
 
 function stripExtras<N extends t.Node>(node: N): N {


### PR DESCRIPTION

These are always on by default with `@codemod/parser`.