### PR TITLE
chore(package): remove unnecessary `registry` config

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -100,7 +100,6 @@
     }
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.com/",
     "access": "public"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,6 @@
     "jest": "^24.8.0"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.com/",
     "access": "public"
   }
 }

--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -38,7 +38,6 @@
   ],
   "types": "src/index.d.ts",
   "publishConfig": {
-    "registry": "https://registry.npmjs.com/",
     "access": "public"
   }
 }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -26,7 +26,6 @@
     "ts-jest": "^24.0.2"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.com/",
     "access": "public"
   }
 }


### PR DESCRIPTION

Lerna was considering this a "3rd-party" registry because the config was present at all. This should hopefully make lerna happier.