### PR TITLE
chore(package): really fix package sorting on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,26 @@
   "scripts": {
     "test": "script/ci"
   },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -e $GIT_PARAMS",
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.md": [
+      "prettier --write",
+      "git add"
+    ],
+    "*.ts": [
+      "prettier --write",
+      "git add"
+    ],
+    "package.json": [
+      "sort-package-json",
+      "git add"
+    ]
+  },
   "dependencies": {},
   "devDependencies": {
     "@types/globby": "^8.0.0",
@@ -25,6 +45,7 @@
     "lerna": "^3.10.7",
     "mz": "^2.7.0",
     "prettier": "^1.15.3",
+    "sort-package-json": "^1.22.1",
     "ts-node": "^7.0.1",
     "typescript": "^3.5.3"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,25 +23,6 @@
     "prepare": "tsc",
     "test": "script/ci"
   },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -e $GIT_PARAMS",
-      "post-checkout": "yarnhook",
-      "post-merge": "yarnhook",
-      "post-rewrite": "yarnhook",
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.md": [
-      "prettier --write",
-      "git add"
-    ],
-    "*.ts": [
-      "prettier --write",
-      "git add"
-    ]
-  },
   "dependencies": {
     "@babel/core": "^7.5.5",
     "@babel/generator": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8740,6 +8740,19 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sort-object-keys@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.2.tgz#d3a6c48dc2ac97e6bc94367696e03f6d09d37952"
+  integrity sha1-06bEjcKsl+a8lDZ2luA/bQnTeVI=
+
+sort-package-json@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.22.1.tgz#384ce7a098cd13be4109800d5ce2f0cf7826052e"
+  integrity sha512-uVINQraFQvnlzNHFnQOT4MYy0qonIEzKwhrI2yrTiQjNo5QF4h3ffrnCk7a95QAwoK/RdkO/w8W9tJIcaOWC7g==
+  dependencies:
+    detect-indent "^5.0.0"
+    sort-object-keys "^1.1.2"
+
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"


### PR DESCRIPTION

Somehow the husky and lint-staged config stayed in packages/cli/package.json even though I moved it at some point.