### PR TITLE
feat: improve ergonomics of capturing matchers

### DIFF
--- a/packages/matchers/src/matchers/capture.ts
+++ b/packages/matchers/src/matchers/capture.ts
@@ -14,12 +14,19 @@ export class CapturedMatcher<C, M = C> extends Matcher<M> {
     super();
   }
 
-  get current(): C | undefined {
+  get current(): C {
+    if (typeof this._current === 'undefined') {
+      throw new Error('there is no currently-captured value');
+    }
     return this._current;
   }
 
   get currentKeys(): ReadonlyArray<PropertyKey> | undefined {
     return this._currentKeys;
+  }
+
+  get hasCaptured(): boolean {
+    return typeof this._current !== 'undefined';
   }
 
   matchValue(value: unknown, keys: ReadonlyArray<PropertyKey>): value is M {
@@ -42,3 +49,5 @@ export default function capture<C, M = C>(
 ): CapturedMatcher<C, M> {
   return new CapturedMatcher(matcher);
 }
+
+capture<undefined>();

--- a/packages/matchers/src/utils/match.ts
+++ b/packages/matchers/src/utils/match.ts
@@ -32,24 +32,24 @@ import * as m from '../../src/matchers';
  *   };
  * }
  */
-export default function match<T, C extends m.CaptureBase>(
+export default function match<T, C extends m.CaptureBase, R = void>(
   matcher: m.Matcher<T>,
   captures: { [K in keyof C]: m.CapturedMatcher<C[K]> },
   value: T,
-  callback: (captures: C) => void
-): void {
+  callback: (captures: C) => R
+): R | void {
   if (matcher.match(value)) {
     const capturedValues = {} as C;
 
     for (const key in captures) {
       if (Object.prototype.hasOwnProperty.call(captures, key)) {
-        const capturedValue = captures[key as keyof C].current;
-        if (capturedValue !== undefined) {
-          capturedValues[key as keyof C] = capturedValue;
+        const capturingMatcher = captures[key as keyof C];
+        if (capturingMatcher.hasCaptured) {
+          capturedValues[key as keyof C] = capturingMatcher.current;
         }
       }
     }
 
-    callback(capturedValues);
+    return callback(capturedValues);
   }
 }

--- a/packages/matchers/src/utils/matchPath.ts
+++ b/packages/matchers/src/utils/matchPath.ts
@@ -63,12 +63,15 @@ export default function matchPath<Node extends t.Node, C extends m.CaptureBase>(
 
     for (const key in captures) {
       if (Object.prototype.hasOwnProperty.call(captures, key)) {
-        const { current, currentKeys } = captures[key as keyof C];
-        if (current !== undefined && currentKeys !== undefined) {
-          capturedPaths[key as keyof C] = extractCapturedPath(
-            value,
-            currentKeys
-          );
+        const capturingMatcher = captures[key as keyof C];
+        if (capturingMatcher.hasCaptured) {
+          const { current, currentKeys } = capturingMatcher;
+          if (current !== undefined && currentKeys !== undefined) {
+            capturedPaths[key as keyof C] = extractCapturedPath(
+              value,
+              currentKeys
+            );
+          }
         }
       }
     }


### PR DESCRIPTION

BREAKING CHANGE: The type of `CapturedMatcher#current` has changed from `C | undefined` to `C`. If the matcher has not captured anything then accessing `#current` will throw. This also adds `CapturedMatcher#hasCaptured` to determine whether a captured value is present.

Additionally, the `match` helper was updated to return the value returned by its callback if the callback was called.

Refs #236