### PR TITLE
chore(deps): unpin ip-regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "resolutions": {
     "**/@babel/parser": "7.6.4",
     "**/@babel/types": "7.6.3",
-    "**/@types/node": "12.11.1",
-    "**/ip-regex": "^2.0.0"
+    "**/@types/node": "12.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4677,10 +4677,10 @@ invariant@^2.2.2, invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ip-regex@^2.0.0, ip-regex@^3.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
-  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+ip-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-3.0.0.tgz#0a934694b4066558c46294244a23cc33116bf732"
+  integrity sha512-T8wDtjy+Qf2TAPDQmBp0eGKJ8GavlWlUnamr3wRn6vvdZlKVuJXXMlSncYFRYgVHOM3If5NR1H4+OvVQU9Idvg==
 
 ip@^1.1.5:
   version "1.1.5"


### PR DESCRIPTION
We no longer support node v6, so there's no reason to use a version of ip-regex that does.