### PR TITLE
fix: put ts-jest in devDependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,6 @@
     "resolve": "^1.7.1",
     "source-map-support": "^0.5.6",
     "tmp": "^0.1.0",
-    "ts-jest": "^24.0.2",
     "whatwg-url": "^7.0.0"
   },
   "devDependencies": {
@@ -68,6 +67,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "rimraf": "3.0.0",
     "semver": "^6.3.0",
+    "ts-jest": "^24.0.2",
     "typescript": "^3.6.4"
   },
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,8 +21,7 @@
     "@babel/generator": "^7.6.4",
     "@codemod/parser": "^1.0.4",
     "recast": "^0.18.1",
-    "resolve": "^1.12.0",
-    "ts-jest": "^24.0.2"
+    "resolve": "^1.12.0"
   },
   "devDependencies": {
     "@babel/types": "^7.6.3",
@@ -31,6 +30,7 @@
     "@types/prettier": "^1.18.0",
     "@types/resolve": "^0.0.8",
     "jest": "^24.8.0",
+    "ts-jest": "^24.0.2",
     "typescript": "^3.6.4"
   },
   "publishConfig": {


### PR DESCRIPTION
I was wondering why I kept having the following warning when installing `codemod`:

```
warning "@codemod/cli > ts-jest@24.2.0" has unmet peer dependency "jest@>=24 <25"
```

It's because some packages declare `ts-jest` as a dependency and not a dev dependency.

This PR fixes it.