### PR TITLE
test(ci): update node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,6 @@ aliases:
 
 version: 2
 jobs:
-  node-v8-latest:
-    docker:
-      - image: circleci/node:8
-    <<: *unit_test
   node-v10-latest:
     docker:
       - image: circleci/node:10
@@ -45,12 +41,16 @@ jobs:
     docker:
       - image: circleci/node:12
     <<: *unit_test
+  node-v13-latest:
+    docker:
+      - image: circleci/node:13
+    <<: *unit_test
 
 workflows:
   version: 2
   test:
     jobs:
-      - node-v8-latest
       - node-v10-latest
       - node-v11-latest
       - node-v12-latest
+      - node-v13-latest


### PR DESCRIPTION
Node v8.x is almost EOL’d and v13.x is here now.