### PR TITLE
test: configure mocha correctly

### DIFF
--- a/packages/cli/test/.mocharc.yml
+++ b/packages/cli/test/.mocharc.yml
@@ -1,0 +1,1 @@
+require: 'source-map-support/register'

--- a/packages/cli/test/mocha.opts
+++ b/packages/cli/test/mocha.opts
@@ -1,1 +1,0 @@
---require source-map-support/register


### PR DESCRIPTION
This silences the warning about `mocha.opts` being deprecated.