### PR TITLE
feat: allow assigning options to plugin positionally

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -43,7 +43,7 @@ For more detailed options, run `codemod --help`.
 
 There are [many, many existing plugins](https://www.npmjs.com/search?q=babel-plugin) that you can use. However, if you need to write your own you should consult the [babel handbook](https://github.com/thejameskyle/babel-handbook). If you publish a plugin intended specifically as a codemod, consider using both the [`babel-plugin`](https://www.npmjs.com/search?q=babel-plugin) and [`babel-codemod`](https://www.npmjs.com/search?q=babel-codemod) keywords.
 
-### Transpiling using babel plugins
+### Transpiling using Babel Plugins
 
 `codemod` also supports non-standard/future language features that are not currently supported by the latest version of node. It does this by leveraging `@babel/preset-env` which loads the [latest babel plugins](https://github.com/babel/babel/tree/master/packages/babel-preset-env#support-all-plugins-in-babel-that-are-considered-latest). This feature is on by default.
 
@@ -63,8 +63,19 @@ There is experimental support for running plugins written in TypeScript. This is
 For example:
 
 ```sh
-# Run a local plugin written with TypeScript.
+# Run a local plugin written with TypeScript
 $ codemod --plugin ./my-plugin.ts src/
+```
+
+### Passing Options to Plugins
+
+You can pass a JSON object as options to a plugin:
+
+```sh
+# Pass a JSON object literal
+$ codemod --plugin ./my-plugin.ts --plugin-options '{"opt": true}'
+# Pass a JSON object from a file
+$ codemod --plugin ./my-plugin.ts --plugin-options @opts.json
 ```
 
 ## Contributing

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -43,7 +43,7 @@ OPTIONS
       --remote-plugin URL           Fetch a plugin from URL${optionAnnotation(
         defaults.remotePlugins
       )}.
-  -o, --plugin-options PLUGIN=OPTS  JSON-encoded OPTS for PLUGIN${optionAnnotation(
+  -o, --plugin-options OPTS         JSON-encoded OPTS for the last plugin provided${optionAnnotation(
     defaults.pluginOptions
   )}.
   -r, --require PATH                Require PATH before transform${optionAnnotation(

--- a/packages/cli/test/cli/CLITest.ts
+++ b/packages/cli/test/cli/CLITest.ts
@@ -657,4 +657,26 @@ describe('CLI', function () {
       }
     )
   })
+
+  it('can pass options to a plugin without naming it', async function () {
+    const { status, stdout, stderr } = await runCodemodCLI(
+      [
+        '--plugin',
+        plugin('append-options-string', '.ts'),
+        '--plugin-options',
+        `${JSON.stringify({ a: 4 })}`,
+        '--stdio',
+      ],
+      ''
+    )
+
+    deepEqual(
+      { status, stdout, stderr },
+      {
+        status: 0,
+        stdout: `${JSON.stringify(JSON.stringify({ a: 4 }))};`,
+        stderr: '',
+      }
+    )
+  })
 })

--- a/packages/cli/test/fixtures/plugin/append-options-string.ts
+++ b/packages/cli/test/fixtures/plugin/append-options-string.ts
@@ -1,0 +1,14 @@
+import { PluginObj, NodePath } from '@babel/core'
+import * as t from '@babel/types'
+
+export default function <T>(_: unknown, options: T): PluginObj {
+  return {
+    visitor: {
+      Program(path: NodePath<t.Program>): void {
+        path.node.body.push(
+          t.expressionStatement(t.stringLiteral(JSON.stringify(options)))
+        )
+      },
+    },
+  }
+}

--- a/packages/cli/test/unit/OptionsTest.ts
+++ b/packages/cli/test/unit/OptionsTest.ts
@@ -88,6 +88,21 @@ describe('Options', function () {
     deepEqual(config.pluginOptions.get('basic-plugin'), { a: true })
   })
 
+  it('assigns anonymous options to the most recent plugin', async function () {
+    const config = getRunConfig(
+      new Options([
+        '--plugin',
+        './test/fixtures/plugin/index.js',
+        '--plugin-options',
+        '{"a": true}',
+      ]).parse()
+    )
+
+    deepEqual(config.pluginOptions.get('./test/fixtures/plugin/index.js'), {
+      a: true,
+    })
+  })
+
   it('interprets `--require` as expected', function () {
     const config = getRunConfig(new Options(['--require', 'tmp']).parse())
     deepEqual(


### PR DESCRIPTION
With this users can do e.g. `codemod -p my-plugin -o @opts1.json -p my-plugin2 -o @opts2.json …` and have `opts1.json` be used for `my-plugin`'s options and `opts2.json` be used for `my-plugin2`'s options. Previously users had to specify the name of the plugin (or its file basename) when assigning options. Now the CLI can infer it based on argument position.

This preserves the feature of using the declared plugin name, but fails gracefully if doing so throws an exception. The downside is that this feature can, if the plugin instantiation throws, silently fail for reasons that are not clear. I think this trade-off is probably worth it.

Closes #686

cc @RIP21