### PR TITLE
Use globby instead of a custom directory traversal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "**/*.js": { "when": "$(basename).ts" },
     "**/*.d.ts": { "when": "$(basename).ts" },
     "**/*.js.map": true
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/cli/src/CLIEngine.ts
+++ b/packages/cli/src/CLIEngine.ts
@@ -54,25 +54,19 @@ export default class CLIEngine {
     let errors = 0
     let total = 0
     const dryRun = this.config.dry
-    let sourcesIterator: IterableIterator<Source>
+    let sources: Array<Source>
 
     if (this.config.stdio) {
-      sourcesIterator = [
-        new Source('<stdin>', await getStream(this.sys.stdin)),
-      ][Symbol.iterator]()
+      sources = [new Source('<stdin>', await getStream(this.sys.stdin))]
     } else {
-      sourcesIterator = iterateSources(
+      sources = iterateSources(
         this.config.sourcePaths,
         this.config.extensions,
-        this.config.ignore,
         this.sys
       )
     }
 
-    const runner = new TransformRunner(
-      sourcesIterator,
-      new InlineTransformer(plugins)
-    )
+    const runner = new TransformRunner(sources, new InlineTransformer(plugins))
 
     for await (const result of runner.run()) {
       this.onTransform(result)

--- a/packages/cli/src/Config.ts
+++ b/packages/cli/src/Config.ts
@@ -3,14 +3,12 @@ import { ParserOptions } from '@codemod/parser'
 import { basename, extname } from 'path'
 import { install } from 'source-map-support'
 import { TransformableExtensions } from './extensions'
-import { PathPredicate } from './iterateSources'
 import PluginLoader from './PluginLoader'
 import AstExplorerResolver from './resolvers/AstExplorerResolver'
 import FileSystemResolver from './resolvers/FileSystemResolver'
 import NetworkResolver from './resolvers/NetworkResolver'
 import PackageResolver from './resolvers/PackageResolver'
 import { disable, enable } from './transpile-requires'
-import { EntryType } from './System'
 
 export class Plugin {
   readonly declaredName?: string
@@ -33,22 +31,6 @@ export class Plugin {
   }
 }
 
-function defaultIgnorePredicate(
-  path: string,
-  basename: string,
-  root: string,
-  type: EntryType
-): boolean {
-  return (
-    // ignore paths starting with a dot
-    basename.startsWith('.') ||
-    // ignore TypeScript declaration files
-    (basename.endsWith('.d.ts') && type === EntryType.File) ||
-    // ignore node_modules directories
-    (basename === 'node_modules' && type === EntryType.Directory)
-  )
-}
-
 export default class Config {
   constructor(
     readonly sourcePaths: Array<string> = [],
@@ -59,7 +41,6 @@ export default class Config {
     readonly sourceType: ParserOptions['sourceType'] = 'unambiguous',
     readonly requires: Array<string> = [],
     readonly transpilePlugins: boolean = true,
-    readonly ignore: PathPredicate = defaultIgnorePredicate,
     readonly stdio: boolean = false,
     readonly dry: boolean = false
   ) {}
@@ -188,7 +169,6 @@ export class ConfigBuilder {
   private _sourceType: ParserOptions['sourceType'] = 'module'
   private _requires?: Array<string>
   private _transpilePlugins?: boolean
-  private _ignore?: PathPredicate
   private _stdio?: boolean
   private _dry?: boolean
 
@@ -287,11 +267,6 @@ export class ConfigBuilder {
     return this
   }
 
-  ignore(value: PathPredicate): this {
-    this._ignore = value
-    return this
-  }
-
   stdio(value: boolean): this {
     this._stdio = value
     return this
@@ -312,7 +287,6 @@ export class ConfigBuilder {
       this._sourceType,
       this._requires,
       this._transpilePlugins,
-      this._ignore,
       this._stdio,
       this._dry
     )

--- a/packages/cli/src/Options.ts
+++ b/packages/cli/src/Options.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from 'fs'
-import { hasMagic as hasGlob, sync as globSync } from 'globby'
 import { resolve } from 'path'
 import { sync as resolveSync } from 'resolve'
 import Config, { ConfigBuilder } from './Config'
@@ -156,11 +155,7 @@ export default class Options {
           if (arg[0] === '-') {
             throw new Error(`unexpected option: ${arg}`)
           } else {
-            if (hasGlob(arg)) {
-              config.addSourcePaths(...globSync(arg))
-            } else {
-              config.addSourcePath(arg)
-            }
+            config.addSourcePath(arg)
           }
           break
       }

--- a/packages/cli/src/TransformRunner.ts
+++ b/packages/cli/src/TransformRunner.ts
@@ -19,7 +19,7 @@ export type SourceTransformResult =
 
 export default class TransformRunner {
   constructor(
-    readonly sources: IterableIterator<Source> | Array<Source>,
+    readonly sources: Array<Source>,
     readonly transformer: Transformer
   ) {}
 

--- a/packages/cli/src/extensions.ts
+++ b/packages/cli/src/extensions.ts
@@ -2,11 +2,21 @@ function union<T>(...sets: Array<Set<T>>): Set<T> {
   return new Set(sets.reduce((result, set) => [...result, ...set], []))
 }
 
-export const TypeScriptExtensions = new Set(['.ts', '.tsx'])
+export const TypeScriptExtensions = new Set([
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.mtsx',
+  '.cts',
+  '.ctsx',
+])
 export const JavaScriptExtensions = new Set([
   '.js',
   '.jsx',
   '.mjs',
+  '.mjsx',
+  '.cjs',
+  '.cjsx',
   '.es',
   '.es6',
 ])

--- a/packages/cli/test/helpers/copyFixturesInto.ts
+++ b/packages/cli/test/helpers/copyFixturesInto.ts
@@ -12,7 +12,7 @@ export default async function copyFixturesInto(
 ): Promise<string> {
   const fixturePath = join('test/fixtures', fixture)
 
-  for (const file of iterateSources([fixturePath], null, () => false)) {
+  for (const file of iterateSources([fixturePath])) {
     const relativePath = relative(fixturePath, file.path)
     const destinationPath = join(destination, relativePath)
     await mkdirp(dirname(destinationPath))

--- a/packages/cli/test/unit/OptionsTest.ts
+++ b/packages/cli/test/unit/OptionsTest.ts
@@ -53,16 +53,6 @@ describe('Options', function () {
     deepEqual(config.sourcePaths, ['src/', 'a.js'])
   })
 
-  it('treats sources as globs', function () {
-    const config = getRunConfig(
-      new Options(['test/fixtures/glob-test/**/*.js']).parse()
-    )
-    deepEqual(config.sourcePaths, [
-      'test/fixtures/glob-test/abc.js',
-      'test/fixtures/glob-test/subdir/def.js',
-    ])
-  })
-
   it('interprets `--stdio` as reading/writing stdin/stdout', function () {
     const config = getRunConfig(new Options(['--stdio']).parse())
     strictEqual(config.stdio, true)


### PR DESCRIPTION
Fixes #770.

There are two failing tests around prettier. I looked at them for a bit and couldn't figure it out. Are you able to take a look and see if anything jumps out?

I used `--no-verify` to bypass the commit formatting rules. If you don't want to squash merge, then I'll reformat my commit to be right once the PR is approved.

I will add docs / update the version number / etc once you approve the basic shape of this.