### PR TITLE
docs(matchers): correcting identifier name

### DIFF
--- a/packages/matchers/README.md
+++ b/packages/matchers/README.md
@@ -254,7 +254,7 @@ const doneParamName = m.capture(m.anyString())
 const matcher = m.callExpression(m.identifier('test'), [
   m.anyString(),
   m.function(
-    [m.identifier(doneParam)],
+    [m.identifier(doneParamName)],
     m.containerOf(m.callExpression(m.identifier(m.fromCapture(doneParamName))))
   ),
 ])


### PR DESCRIPTION
* updating the docs to use the correct identifier name in the deep matches section example

Closes #886.