### PR TITLE
feat(cli): add `--parser-plugins` option

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.2.0](https://github.com/codemod-js/codemod/compare/@codemod/cli@3.1.1...@codemod/cli@3.2.0) (2023-02-17)
+
+### Features
+
+- **cli:** add `--parser-plugins` option ([3593893](https://github.com/codemod-js/codemod/commit/3593893791c7e4e0e0c8cea31ea642b229c0bb8a))
+
 ## [3.1.0](https://github.com/codemod-js/codemod/compare/@codemod/cli@3.0.1...@codemod/cli@3.1.0) (2021-11-14)
 
 - **feat:** improve gitignore handling ([e04c0c4](https://github.com/codemod-js/codemod/commit/e04c0c41d5cb3d86c6cdbbac932efcad968c73c9))

--- a/packages/cli/__tests__/unit/InlineTransformer.test.ts
+++ b/packages/cli/__tests__/unit/InlineTransformer.test.ts
@@ -1,8 +1,8 @@
+import { PluginItem } from '@babel/core'
 import { NodePath } from '@babel/traverse'
 import { NumericLiteral, Program } from '@babel/types'
 import { join } from 'path'
 import InlineTransformer from '../../src/InlineTransformer'
-import { PluginItem } from '@babel/core'
 
 test('passes source through as-is when there are no plugins', async function () {
   const filepath = 'a.js'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod/cli",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "codemod rewrites JavaScript and TypeScript",
   "repository": "https://github.com/codemod-js/codemod.git",
   "license": "Apache-2.0",
@@ -32,8 +32,8 @@
     "@babel/preset-typescript": "^7.18.6",
     "@babel/traverse": "^7.20.13",
     "@babel/types": "^7.20.7",
-    "@codemod/core": "^2.0.1",
-    "@codemod/parser": "^1.2.1",
+    "@codemod/core": "^2.1.0",
+    "@codemod/parser": "^1.3.0",
     "core-js": "^3.1.4",
     "esbuild": "^0.13.13",
     "esbuild-runner": "^2.2.1",

--- a/packages/cli/src/CLIEngine.ts
+++ b/packages/cli/src/CLIEngine.ts
@@ -1,6 +1,5 @@
-import { promises as fs } from 'fs'
-import getStream = require('get-stream')
 import { PluginItem } from '@babel/core'
+import { promises as fs } from 'fs'
 import Config from './Config'
 import InlineTransformer from './InlineTransformer'
 import iterateSources from './iterateSources'
@@ -9,6 +8,7 @@ import TransformRunner, {
   SourceTransformResult,
   SourceTransformResultKind,
 } from './TransformRunner'
+import getStream = require('get-stream')
 
 export class RunResult {
   constructor(readonly stats: RunStats) {}
@@ -54,7 +54,10 @@ export default class CLIEngine {
       })
     }
 
-    const runner = new TransformRunner(sources, new InlineTransformer(plugins))
+    const runner = new TransformRunner(
+      sources,
+      new InlineTransformer(plugins, this.config.parserPlugins)
+    )
 
     for await (const result of runner.run()) {
       this.onTransform(result)

--- a/packages/cli/src/Config.ts
+++ b/packages/cli/src/Config.ts
@@ -1,5 +1,5 @@
 import * as Babel from '@babel/core'
-import { ParserOptions } from '@codemod/parser'
+import { ParserOptions, ParserPluginName } from '@codemod/parser'
 import { basename, extname } from 'path'
 import { TransformableExtensions } from './extensions'
 import PluginLoader from './PluginLoader'
@@ -35,6 +35,7 @@ export default class Config {
     readonly localPlugins: Array<string> = [],
     readonly remotePlugins: Array<string> = [],
     readonly pluginOptions: Map<string, object> = new Map<string, object>(),
+    readonly parserPlugins = new Set<ParserPluginName>(),
     readonly extensions: Set<string> = TransformableExtensions,
     readonly sourceType: ParserOptions['sourceType'] = 'unambiguous',
     readonly requires: Array<string> = [],
@@ -156,6 +157,7 @@ export class ConfigBuilder {
   private _localPlugins?: Array<string>
   private _remotePlugins?: Array<string>
   private _pluginOptions?: Map<string, object>
+  private _parserPluginNames = new Set<ParserPluginName>()
   private _extensions: Set<string> = new Set(TransformableExtensions)
   private _sourceType: ParserOptions['sourceType'] = 'module'
   private _requires?: Array<string>
@@ -222,6 +224,11 @@ export class ConfigBuilder {
     return this
   }
 
+  addParserPlugin(name: ParserPluginName): this {
+    this._parserPluginNames.add(name)
+    return this
+  }
+
   extensions(value: Set<string>): this {
     this._extensions = value
     return this
@@ -274,6 +281,7 @@ export class ConfigBuilder {
       this._localPlugins,
       this._remotePlugins,
       this._pluginOptions,
+      this._parserPluginNames,
       this._extensions,
       this._sourceType,
       this._requires,

--- a/packages/cli/src/InlineTransformer.ts
+++ b/packages/cli/src/InlineTransformer.ts
@@ -1,16 +1,23 @@
-import Transformer from './Transformer'
-import { transform, TransformOptions } from '@codemod/core'
 import { PluginItem } from '@babel/core'
+import { ParserPlugin } from '@babel/parser'
+import { transform, TransformOptions } from '@codemod/core'
+import Transformer from './Transformer'
 
 export default class InlineTransformer implements Transformer {
-  constructor(private readonly plugins: Array<PluginItem>) {}
+  constructor(
+    private readonly plugins: Iterable<PluginItem>,
+    private readonly parserPlugins: Iterable<ParserPlugin> = []
+  ) {}
 
   async transform(filepath: string, content: string): Promise<string> {
     const options: TransformOptions = {
       filename: filepath,
       babelrc: false,
       configFile: false,
-      plugins: this.plugins,
+      plugins: [...this.plugins],
+      parserOpts: {
+        plugins: [...this.parserPlugins],
+      },
     }
 
     const result = transform(content, options)

--- a/packages/cli/src/Options.ts
+++ b/packages/cli/src/Options.ts
@@ -1,3 +1,4 @@
+import { isParserPluginName } from '@codemod/parser'
 import { existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
 import { sync as resolveSync } from 'resolve'
@@ -85,6 +86,22 @@ export default class Options {
             throw new Error(
               `unable to parse JSON config for ${name}: ${optionsRaw}`
             )
+          }
+          break
+        }
+
+        case '--parser-plugins': {
+          i++
+          const value = this.args[i]
+          if (!value) {
+            throw new Error(`${arg} must be followed by a comma-separated list`)
+          }
+          for (const plugin of value.split(',')) {
+            if (isParserPluginName(plugin)) {
+              config.addParserPlugin(plugin)
+            } else {
+              throw new Error(`unknown parser plugin: ${plugin}`)
+            }
           }
           break
         }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,6 +39,7 @@ OPTIONS
   -o, --plugin-options OPTS         JSON-encoded OPTS for the last plugin provided${optionAnnotation(
     defaults.pluginOptions
   )}.
+      --parser-plugins PLUGINS      Comma-separated PLUGINS to use with @babel/parser.
   -r, --require PATH                Require PATH before transform${optionAnnotation(
     defaults.requires
   )}.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/codemod-js/codemod/compare/@codemod/core@2.0.0...@codemod/core@2.1.0) (2023-02-17)
+
+### Bug Fixes
+
+- update intra-monorepo dependencies ([3c95444](https://github.com/codemod-js/codemod/commit/3c95444e1f57b982634e635931ca08ecf5805e21))
+
+### Features
+
+- **cli,core:** use `esbuild-runner` ([ab527b2](https://github.com/codemod-js/codemod/commit/ab527b2cea23211732ab1a45512dc1f968c707c6))
+- **cli:** add `--parser-plugins` option ([3593893](https://github.com/codemod-js/codemod/commit/3593893791c7e4e0e0c8cea31ea642b229c0bb8a))
+
 ## [2.0.0](https://github.com/codemod-js/codemod/compare/@codemod/core@1.1.1...@codemod/core@2.0.0) (2021-11-12)
 
 - remove underused options: `--printer`, `--babelrc`, `--find-babel-config` ([50a864d](https://github.com/codemod-js/codemod/commit/50a864df7344767a5c0e9e3ab990a0f4d05d634d))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod/core",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Runs babel plugins for codemods, i.e. by preserving formatting using Recast.",
   "repository": "https://github.com/codemod-js/codemod",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@babel/core": "^7.20.12",
     "@babel/generator": "^7.20.14",
-    "@codemod/parser": "^1.2.1",
+    "@codemod/parser": "^1.3.0",
     "is-ci-cli": "^2.2.0",
     "recast": "^0.19.0",
     "resolve": "^1.12.0"

--- a/packages/core/src/AllSyntaxPlugin.ts
+++ b/packages/core/src/AllSyntaxPlugin.ts
@@ -1,6 +1,6 @@
 import { buildOptions, ParserOptions } from '@codemod/parser'
-import { BabelPlugin, PluginObj } from './BabelPluginTypes'
 import { TransformOptions } from '.'
+import { BabelPlugin, PluginObj } from './BabelPluginTypes'
 
 export default function buildPlugin(
   sourceType: ParserOptions['sourceType']
@@ -14,6 +14,7 @@ export default function buildPlugin(
         const options = buildOptions({
           ...parserOpts,
           sourceType,
+          plugins: parserOpts.plugins,
         })
 
         for (const key of Object.keys(options)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,11 @@
 import {
-  TransformOptions as BabelTransformOptions,
   BabelFileResult,
+  TransformOptions as BabelTransformOptions,
   transformSync,
 } from '@babel/core'
-import RecastPlugin from './RecastPlugin'
-import buildAllSyntaxPlugin from './AllSyntaxPlugin'
 import { strict as assert } from 'assert'
+import buildAllSyntaxPlugin from './AllSyntaxPlugin'
+import RecastPlugin from './RecastPlugin'
 
 export type TransformOptions = BabelTransformOptions
 

--- a/packages/matchers/CHANGELOG.md
+++ b/packages/matchers/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.3.0](https://github.com/codemod-js/codemod/compare/@codemod/matchers@1.2.0...@codemod/matchers@1.3.0) (2023-02-17)
+
+### Bug Fixes
+
+- update intra-monorepo dependencies ([3c95444](https://github.com/codemod-js/codemod/commit/3c95444e1f57b982634e635931ca08ecf5805e21))
+
+### Features
+
+- **cli,core:** use `esbuild-runner` ([ab527b2](https://github.com/codemod-js/codemod/commit/ab527b2cea23211732ab1a45512dc1f968c707c6))
+
 ## [1.2.0](https://github.com/codemod-js/codemod/compare/@codemod/matchers@1.1.1...@codemod/matchers@1.2.0) (2021-11-12)
 
 - update babel to v7.16.x ([1218bf9](https://github.com/codemod-js/codemod/commit/1218bf98145feaa8a692611152559aa6b46b9ba0))

--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod/matchers",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Matchers for JavaScript & TypeScript codemods.",
   "repository": "https://github.com/codemod-js/codemod",
   "license": "Apache-2.0",
@@ -27,8 +27,8 @@
     "@babel/core": "^7.20.12",
     "@babel/generator": "^7.20.14",
     "@babel/traverse": "^7.20.13",
-    "@codemod/core": "^2.0.1",
-    "@codemod/parser": "^1.2.1",
+    "@codemod/core": "^2.1.0",
+    "@codemod/parser": "^1.3.0",
     "@types/babel__core": "^7.20.0",
     "@types/babel__generator": "^7.6.4",
     "@types/babel__template": "^7.4.1",

--- a/packages/parser/CHANGELOG.md
+++ b/packages/parser/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.3.0](https://github.com/codemod-js/codemod/compare/@codemod/parser@1.2.0...@codemod/parser@1.3.0) (2023-02-17)
+
+### Features
+
+- **cli,core:** use `esbuild-runner` ([ab527b2](https://github.com/codemod-js/codemod/commit/ab527b2cea23211732ab1a45512dc1f968c707c6))
+- **cli:** add `--parser-plugins` option ([3593893](https://github.com/codemod-js/codemod/commit/3593893791c7e4e0e0c8cea31ea642b229c0bb8a))
+
 ## [1.2.0](https://github.com/codemod-js/codemod/compare/@codemod/parser@1.1.1...@codemod/parser@1.2.0) (2021-11-12)
 
 - update babel to v7.16.x ([1218bf9](https://github.com/codemod-js/codemod/commit/1218bf98145feaa8a692611152559aa6b46b9ba0))

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod/parser",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Wrapper around @babel/parser that allows parsing everything.",
   "repository": "https://github.com/codemod-js/codemod",
   "license": "Apache-2.0",

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -3,9 +3,13 @@ import {
   ParserOptions as BabelParserOptions,
 } from '@babel/parser'
 import { File } from '@babel/types'
-import buildOptions, { ParserOptions } from './options'
+import buildOptions, {
+  isParserPluginName,
+  ParserOptions,
+  ParserPluginName,
+} from './options'
 
-export { buildOptions, ParserOptions }
+export { buildOptions, isParserPluginName, ParserOptions, ParserPluginName }
 
 /**
  * Wraps `parse` from `@babel/parser`, but sets default options such that as few

--- a/packages/parser/src/options.ts
+++ b/packages/parser/src/options.ts
@@ -8,7 +8,7 @@ import {
   TypeScriptPluginOptions,
 } from '@babel/parser'
 
-type ParserPluginName =
+export type ParserPluginName =
   | Extract<ParserPlugin, string>
   | Extract<ParserPlugin, [string, object]>[0]
 
@@ -40,9 +40,19 @@ const DefaultParserPlugins = new Set<ParserPlugin>([
   'throwExpressions',
   'topLevelAwait',
   ['decorators', { decoratorsBeforeExport: true }],
+  'decorators-legacy',
   ['pipelineOperator', { proposal: 'minimal' }],
   ['recordAndTuple', { syntaxType: 'hash' }],
 ])
+
+export function isParserPluginName(name: string): name is ParserPluginName {
+  for (const plugin of DefaultParserPlugins) {
+    if (name === getPluginName(plugin)) {
+      return true
+    }
+  }
+  return false
+}
 
 export interface ParserOptions extends Omit<BabelParserOptions, 'plugins'> {
   plugins?: Array<ParserPlugin>


### PR DESCRIPTION
This allows directly specifying parser plugins to include, which may override the default plugins used.

Refs #899 