### PR TITLE
fix(matchers): ensure package types work

### DIFF
--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod/matchers",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Matchers for JavaScript & TypeScript codemods.",
   "repository": "https://github.com/codemod-js/codemod",
   "license": "Apache-2.0",

--- a/packages/matchers/src/utils/match.ts
+++ b/packages/matchers/src/utils/match.ts
@@ -1,4 +1,4 @@
-import * as m from '../../src/matchers'
+import * as m from '../matchers'
 
 /**
  * This helper makes it easier to use a matcher together with captured values,

--- a/packages/matchers/src/utils/matchPath.ts
+++ b/packages/matchers/src/utils/matchPath.ts
@@ -1,6 +1,6 @@
-import * as m from '../../src/matchers'
-import * as t from '@babel/types'
 import { NodePath } from '@babel/core'
+import * as t from '@babel/types'
+import * as m from '../matchers'
 
 export type CapturedNodePaths<C> = {
   [K in keyof C]: C[K] extends t.Node ? NodePath<C[K]> : C[K]


### PR DESCRIPTION
The built package had types with an import specifier containing `../../src/matchers`. However, since `src` was the build root directory it does not appear in the final output structure. This rendered the import specifier invalid, breaking the types for the `match` and `matchPath` utilities. The fix was to use the correct shortest relative path.

Fixes #898 