### PR TITLE
feat(matchers): `fromCapture` structural matches

### DIFF
--- a/packages/matchers/README.md
+++ b/packages/matchers/README.md
@@ -121,12 +121,12 @@ Sometimes you'll want to refer to an earlier captured value in a later part of t
 ```ts
 import * as m from '@codemod/matchers'
 
-const argumentNameMatcher = m.capture(m.anyString())
+const argumentMatcher = m.capture(m.identifier())
 const matcher = m.functionExpression(
   m.anything(),
-  [m.identifier(argumentNameMatcher)],
+  [argumentMatcher],
   m.blockStatement([
-    m.returnStatement(m.fromCapture(m.identifier(argumentNameMatcher))),
+    m.returnStatement(m.fromCapture(argumentMatcher)),
   ])
 )
 
@@ -159,12 +159,12 @@ export default function () {
   return {
     visitor: {
       FunctionExpression(path: NodePath<t.FunctionExpression>): void {
-        const argumentNameMatcher = m.capture(m.anyString())
+        const argumentMatcher = m.capture(m.identifier())
         const matcher = m.functionExpression(
           m.anything(),
-          [m.identifier(argumentNameMatcher)],
+          [argumentMatcher],
           m.blockStatement([
-            m.returnStatement(m.fromCapture(m.identifier(argumentNameMatcher))),
+            m.returnStatement(m.fromCapture(argumentMatcher)),
           ])
         )
 
@@ -250,12 +250,12 @@ Sometimes you know you want to match a node but don't know its depth in the tree
 ```ts
 import * as m from '@codemod/matchers'
 
-const doneParamName = m.capture(m.anyString())
+const doneParam = m.capture(m.identifier())
 const matcher = m.callExpression(m.identifier('test'), [
   m.anyString(),
   m.function(
-    [m.identifier(doneParamName)],
-    m.containerOf(m.callExpression(m.identifier(m.fromCapture(doneParamName))))
+    [doneParam],
+    m.containerOf(m.callExpression(m.fromCapture(doneParam)))
   ),
 ])
 

--- a/packages/matchers/jest.config.js
+++ b/packages/matchers/jest.config.js
@@ -9,5 +9,9 @@ module.exports = {
   transform: {
     '\\.ts$': 'esbuild-runner/jest',
   },
-  collectCoverageFrom: ['!src/matchers.ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!**/__tests__/**/*.ts',
+    '!src/matchers.ts',
+  ],
 }

--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod/matchers",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Matchers for JavaScript & TypeScript codemods.",
   "repository": "https://github.com/codemod-js/codemod",
   "license": "Apache-2.0",

--- a/packages/matchers/src/__tests__/matchers.test.ts
+++ b/packages/matchers/src/__tests__/matchers.test.ts
@@ -1,5 +1,5 @@
-import * as m from '../matchers'
 import * as t from '@babel/types'
+import * as m from '../matchers'
 import js from './utils/parse/js'
 
 test('anyString matches strings', () => {
@@ -305,4 +305,23 @@ test('matcher builds a matcher based on a predicate', () => {
   expect(matcher.match('another')).toBeFalsy()
   expect(matcher.match({})).toBeFalsy()
   expect(matcher.match(42)).toBeFalsy()
+})
+
+test('fromCapture builds a matcher based on a capturing matcher', () => {
+  const capture = m.capture(m.identifier())
+  const matcher = m.fromCapture(capture)
+  const id = t.identifier('a')
+  const idEquivalent = t.identifier('a')
+  const idUnequivalent = t.identifier('b')
+
+  // matching the capture matcher should capture the value
+  expect(capture.current).toBeUndefined()
+  expect(capture.match(id)).toBeTruthy()
+  expect(capture.current).toBe(id)
+
+  // `fromCapture` uses the captured value to build a matcher
+  expect(matcher.match(id)).toBeTruthy()
+  expect(matcher.match(idEquivalent)).toBeTruthy()
+  expect(matcher.match(idUnequivalent)).toBeFalsy()
+  expect(matcher.match(9)).toBeFalsy()
 })

--- a/packages/matchers/src/__tests__/nodesEquivalent.test.ts
+++ b/packages/matchers/src/__tests__/nodesEquivalent.test.ts
@@ -1,0 +1,66 @@
+import * as t from '@babel/types'
+import { nodesEquivalent } from '../utils/nodesEquivalent'
+
+test('a node is equivalent to itself', () => {
+  const node = t.identifier('a')
+  expect(nodesEquivalent(node, node)).toBe(true)
+})
+
+test('two nodes with different types are not equivalent', () => {
+  const a = t.identifier('a')
+  const two = t.numericLiteral(2)
+  expect(nodesEquivalent(a, two)).toBe(false)
+})
+
+test('two nodes with the same type and the same properties are equivalent', () => {
+  const a = t.identifier('a')
+  const b = t.identifier('a')
+  expect(nodesEquivalent(a, b)).toBe(true)
+})
+
+test('two nodes with the same type and different properties are not equivalent', () => {
+  const a = t.identifier('a')
+  const b = t.identifier('b')
+  expect(nodesEquivalent(a, b)).toBe(false)
+})
+
+test('two nodes with differing optional properties are not equivalent', () => {
+  const a = t.identifier('a')
+  const b = t.identifier('a')
+  a.typeAnnotation = t.tsTypeAnnotation(t.tsAnyKeyword())
+  expect(nodesEquivalent(a, b)).toBe(false)
+})
+
+test('two nodes with different children are not equivalent', () => {
+  const a = t.arrayExpression([t.identifier('a')])
+  const b = t.arrayExpression([t.identifier('b')])
+  expect(nodesEquivalent(a, b)).toBe(false)
+})
+
+test('two nodes with differing number of children are not equivalent', () => {
+  const a = t.arrayExpression([t.identifier('a')])
+  const b = t.arrayExpression([t.identifier('a'), t.identifier('b')])
+  expect(nodesEquivalent(a, b)).toBe(false)
+})
+
+test('two nodes with the same children are equivalent', () => {
+  const a = t.arrayExpression([t.identifier('a')])
+  const b = t.arrayExpression([t.identifier('a')])
+  expect(nodesEquivalent(a, b)).toBe(true)
+})
+
+test('two nodes with equivalent fixed children are equivalent', () => {
+  const a = t.identifier('a')
+  const b = t.identifier('a')
+  a.typeAnnotation = t.tsTypeAnnotation(t.tsAnyKeyword())
+  b.typeAnnotation = t.tsTypeAnnotation(t.tsAnyKeyword())
+  expect(nodesEquivalent(a, b)).toBe(true)
+})
+
+test('two nodes with non-equivalent fixed children are not equivalent', () => {
+  const a = t.identifier('a')
+  const b = t.identifier('a')
+  a.typeAnnotation = t.tsTypeAnnotation(t.tsUnknownKeyword())
+  b.typeAnnotation = t.tsTypeAnnotation(t.tsAnyKeyword())
+  expect(nodesEquivalent(a, b)).toBe(false)
+})

--- a/packages/matchers/src/matchers/fromCapture.ts
+++ b/packages/matchers/src/matchers/fromCapture.ts
@@ -1,4 +1,6 @@
 import { CapturedMatcher } from '../matchers'
+import { isNode } from '../NodeTypes'
+import { nodesEquivalent } from '../utils/nodesEquivalent'
 import Matcher from './Matcher'
 
 export class FromCaptureMatcher<T> extends Matcher<T> {
@@ -7,10 +9,20 @@ export class FromCaptureMatcher<T> extends Matcher<T> {
   }
 
   matchValue(value: unknown): value is T {
+    if (isNode(this.capturedMatcher.current) && isNode(value)) {
+      return nodesEquivalent(this.capturedMatcher.current, value)
+    }
     return this.capturedMatcher.current === value
   }
 }
 
+/**
+ * Matches the value captured by `capturedMatcher`, which must match its value
+ * before this matcher. That is, `capturedMatcher` must match a value that is
+ * visited before this matcher. If `capturedMatcher` matches a node, this
+ * matcher will match a node that is equivalent–but not necessarily identical–to
+ * the captured node.
+ */
 export default function fromCapture<T>(
   capturedMatcher: CapturedMatcher<T>
 ): Matcher<T> {

--- a/packages/matchers/src/utils/nodesEquivalent.ts
+++ b/packages/matchers/src/utils/nodesEquivalent.ts
@@ -1,0 +1,64 @@
+import * as t from '@babel/types'
+import { NODE_FIELDS } from '../NodeTypes'
+
+/**
+ * Determines whether two `@babel/types` nodes are equivalent.
+ */
+export function nodesEquivalent(a: t.Node, b: t.Node): boolean {
+  if (a === b) {
+    return true
+  }
+
+  if (a.type !== b.type) {
+    return false
+  }
+
+  const fields = NODE_FIELDS[a.type]
+  const aProps = a as unknown as { [key: string]: unknown }
+  const bProps = b as unknown as { [key: string]: unknown }
+
+  for (const [k, field] of Object.entries(fields)) {
+    const key = k as keyof typeof fields
+
+    if (field.optional && aProps[key] == null && bProps[key] == null) {
+      continue
+    }
+
+    const aVal = aProps[key]
+    const bVal = bProps[key]
+
+    if (aVal === bVal) {
+      continue
+    }
+
+    if (aVal == null || bVal == null) {
+      return false
+    }
+
+    if (Array.isArray(aVal) && Array.isArray(bVal)) {
+      if (aVal.length !== bVal.length) {
+        return false
+      }
+
+      for (let i = 0; i < aVal.length; i++) {
+        if (!nodesEquivalent(aVal[i], bVal[i])) {
+          return false
+        }
+      }
+
+      continue
+    }
+
+    if (t.isNode(aVal) && t.isNode(bVal)) {
+      if (!nodesEquivalent(aVal, bVal)) {
+        return false
+      }
+
+      continue
+    }
+
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
Add support for matching nodes using `fromCapture`, which enables more natural captures like this:

```ts
const id = m.capture(m.identifier())
const idPlusIdMatcher = m.binaryExpression('+', id, m.fromCapture(id))
```

Refs #898 