### PR TITLE
docs: update examples

### DIFF
--- a/packages/matchers/README.md
+++ b/packages/matchers/README.md
@@ -125,9 +125,7 @@ const argumentMatcher = m.capture(m.identifier())
 const matcher = m.functionExpression(
   m.anything(),
   [argumentMatcher],
-  m.blockStatement([
-    m.returnStatement(m.fromCapture(argumentMatcher)),
-  ])
+  m.blockStatement([m.returnStatement(m.fromCapture(argumentMatcher))])
 )
 
 matcher.match(expr('function(a) { return a; })')) // true
@@ -163,9 +161,7 @@ export default function () {
         const matcher = m.functionExpression(
           m.anything(),
           [argumentMatcher],
-          m.blockStatement([
-            m.returnStatement(m.fromCapture(argumentMatcher)),
-          ])
+          m.blockStatement([m.returnStatement(m.fromCapture(argumentMatcher))])
         )
 
         if (matcher.match(path.node)) {
@@ -383,16 +379,12 @@ export default function () {
   return {
     visitor: {
       FunctionExpression(path: NodePath<t.FunctionExpression>): void {
-        const argumentNameMatcher = m.capture(m.anyString())
+        const paramId = m.capture(m.identifier())
         const matcher = m.function(
-          [m.identifier(argumentNameMatcher)],
+          [paramId],
           m.or(
-            m.blockStatement([
-              m.returnStatement(
-                m.identifier(m.fromCapture(argumentNameMatcher))
-              ),
-            ]),
-            m.identifier(m.fromCapture(argumentNameMatcher))
+            m.blockStatement([m.returnStatement(m.fromCapture(paramId))]),
+            m.fromCapture(paramId)
           )
         )
 

--- a/packages/matchers/examples/convert-static-class-to-named-exports.ts
+++ b/packages/matchers/examples/convert-static-class-to-named-exports.ts
@@ -59,12 +59,12 @@ import * as t from '@babel/types'
 import * as m from '../src'
 
 // capture the name of the exported class
-const className = m.capture(m.anyString())
+const classId = m.capture(m.identifier())
 
 // capture the class declaration
 const classDeclaration = m.capture(
   m.classDeclaration(
-    m.identifier(className),
+    classId,
     undefined,
     m.classBody(
       m.arrayOf(
@@ -91,7 +91,7 @@ const classDeclaration = m.capture(
 
 // capture the export, making sure to match the class name
 const exportDeclaration = m.capture(
-  m.exportDefaultDeclaration(m.identifier(m.fromCapture(className)))
+  m.exportDefaultDeclaration(m.fromCapture(classId))
 )
 
 // match a program that contains a matching class and export declaration


### PR DESCRIPTION
This finishes converting the examples to use structural matching with `fromCapture`.

Refs #904 