### PR TITLE
fix(matchers): correct `or` types

### DIFF
--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod/matchers",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Matchers for JavaScript & TypeScript codemods.",
   "repository": "https://github.com/codemod-js/codemod",
   "license": "Apache-2.0",

--- a/packages/matchers/src/__tests__/matchers.test.ts
+++ b/packages/matchers/src/__tests__/matchers.test.ts
@@ -1,6 +1,11 @@
 import { js, t } from '@codemod/utils'
 import * as m from '../matchers'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function expectType<T>(value: T): void {
+  // nothing to do
+}
+
 test('anyString matches strings', () => {
   expect(m.anyString().match('')).toBeTruthy()
   expect(m.anyString().match('abc')).toBeTruthy()
@@ -223,20 +228,32 @@ test('anyList with multiple dynamic spacers', () => {
 })
 
 test('or matches one of the values', () => {
+  const mString = m.or(m.anyString())
+  const mStringOrNumber = m.or(m.anyString(), m.anyNumber())
+  const mStringOrNumberOrNull = m.or(m.anyString(), m.anyNumber(), null)
+  expectType<m.Matcher<string>>(mString)
+  expectType<m.Matcher<string | number>>(mStringOrNumber)
+  expectType<m.Matcher<string | number | null>>(mStringOrNumberOrNull)
+
   expect(m.or().match(undefined)).toBeFalsy()
-  expect(m.or(m.anyString()).match('')).toBeTruthy()
-  expect(m.or(m.anyString(), m.anyNumber()).match(1)).toBeTruthy()
-  expect(m.or(m.anyString(), m.anyNumber()).match('')).toBeTruthy()
-  expect(m.or(m.anyString(), m.anyNumber(), null).match(null)).toBeTruthy()
-  expect(m.or(m.anyString(), m.anyNumber()).match({})).toBeFalsy()
+  expect(mString.match('')).toBeTruthy()
+  expect(mStringOrNumber.match(1)).toBeTruthy()
+  expect(mStringOrNumber.match('')).toBeTruthy()
+  expect(mStringOrNumberOrNull.match(null)).toBeTruthy()
+  expect(mStringOrNumber.match({})).toBeFalsy()
 })
 
 test('or matches literal values', () => {
-  expect(m.or(1).match(1)).toBeTruthy()
-  expect(m.or(1, 2).match(1)).toBeTruthy()
-  expect(m.or(1, 2).match(2)).toBeTruthy()
-  expect(m.or(1, 2).match(3)).toBeFalsy()
-  expect(m.or(1, 2).match({})).toBeFalsy()
+  const m1 = m.or(1)
+  const m1or2 = m.or(1, 2)
+  expectType<m.Matcher<number>>(m1)
+  expectType<m.Matcher<number>>(m1or2)
+
+  expect(m1.match(1)).toBeTruthy()
+  expect(m1or2.match(1)).toBeTruthy()
+  expect(m1or2.match(2)).toBeTruthy()
+  expect(m1or2.match(3)).toBeFalsy()
+  expect(m1or2.match({})).toBeFalsy()
 })
 
 test('or matches mixed literal values and matchers', () => {

--- a/packages/matchers/src/matchers/or.ts
+++ b/packages/matchers/src/matchers/or.ts
@@ -22,24 +22,24 @@ export class OrMatcher<T, A extends Array<Matcher<T> | T>> extends Matcher<T> {
   }
 }
 
-export default function or<T>(): Matcher<T>
-export default function or<T>(first: Matcher<T> | T): Matcher<T>
-export default function or<T, U>(
+export function or(): Matcher<never>
+export function or<T>(first: Matcher<T> | T): Matcher<T>
+export function or<T, U>(
   first: Matcher<T> | T,
   second: Matcher<U> | U
 ): Matcher<T | U>
-export default function or<T, U, V>(
+export function or<T, U, V>(
   first: Matcher<T> | T,
   second: Matcher<U> | U,
   third: Matcher<V> | V
 ): Matcher<T | U | V>
-export default function or<T, U, V, W>(
+export function or<T, U, V, W>(
   first: Matcher<T> | T,
   second: Matcher<U> | U,
   third: Matcher<V> | V,
   fourth: Matcher<W> | W
 ): Matcher<T | U | V | W>
-export default function or<T, U, V, W, X>(
+export function or<T, U, V, W, X>(
   first: Matcher<T> | T,
   second: Matcher<U> | U,
   third: Matcher<V> | V,


### PR DESCRIPTION
When I moved away from default exports I neglected to update these exports so only the generic `or` declaration was used.