### PR TITLE
fix: ensure TS abstract classes parse correctly

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod/parser",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Wrapper around @babel/parser that allows parsing everything.",
   "repository": "https://github.com/codemod-js/codemod",
   "license": "Apache-2.0",

--- a/packages/parser/src/__tests__/test.ts
+++ b/packages/parser/src/__tests__/test.ts
@@ -122,8 +122,6 @@ test('parses with a very broad set of options', () => {
       export { a };
       // demonstrate 'typescript' plugin
       type Foo = Extract<PropertyKey, string>;
-      // demonstrate 'placeholders' plugin
-      %%statement%%
       // demonstrate 'logicalAssignment' plugin
       a ||= b
       // demonstrate 'partialApplication' plugin
@@ -139,12 +137,23 @@ test('parses with a very broad set of options', () => {
     'ReturnStatement',
     'ExportNamedDeclaration',
     'TSTypeAliasDeclaration',
-    'Placeholder',
     'AssignmentExpression',
     'CallExpression',
     'TupleExpression',
     'BinaryExpression',
   ])
+})
+
+test('does not parse placeholders by default as they conflict with TypeScript', () => {
+  const placeholderCode = `
+    // demonstrate 'placeholders' plugin
+    %%statement%%
+  `
+
+  expect(() => parse(placeholderCode)).toThrowError()
+  const node = parse(placeholderCode, { plugins: ['placeholders'] }).program
+    .body[0]
+  expect(node.type).toBe('Placeholder')
 })
 
 test('allows parsing records and tuples with "bar" syntax', () => {
@@ -157,4 +166,14 @@ test('allows parsing records and tuples with "bar" syntax', () => {
   expect(t.isRecordExpression((tuple as t.TupleExpression).elements[2])).toBe(
     true
   )
+})
+
+test('allows parsing of abstract classes with abstract methods', () => {
+  expect(
+    parse(`
+      abstract class Foo {
+        abstract bar(): void;
+      }
+    `).program.body[0].type
+  ).toBe('ClassDeclaration')
 })

--- a/packages/parser/src/options.ts
+++ b/packages/parser/src/options.ts
@@ -36,7 +36,6 @@ const DefaultParserPlugins = new Set<ParserPlugin>([
   'optionalCatchBinding',
   'optionalChaining',
   'partialApplication',
-  'placeholders',
   'throwExpressions',
   'topLevelAwait',
   ['decorators', { decoratorsBeforeExport: true }],

--- a/packages/utils/src/builders.ts
+++ b/packages/utils/src/builders.ts
@@ -15,7 +15,9 @@ export interface ReplacementsBase {
 export function program<R extends ReplacementsBase>(
   template: string
 ): (replacements?: R) => t.File {
-  const ast = parse(template)
+  const ast = parse(template, {
+    plugins: ['placeholders'],
+  })
 
   return (replacements = {} as R) => {
     const unusedReplacements = new Set(Object.keys(replacements))


### PR DESCRIPTION
Something about enabling the `placeholders` parser plugin causes parse errors when a TypeScript `abstract` class method is encountered. I'm not sure why, but this fixes it by disabling the `placeholders` parser plugin by default. It can still be enabled by passing it explicitly.

Closes #917 